### PR TITLE
feat:add bragi children espol theme 

### DIFF
--- a/edx-platform/bragi-children/espol/lms/static/sass/partials/lms/theme/_buttons.scss
+++ b/edx-platform/bragi-children/espol/lms/static/sass/partials/lms/theme/_buttons.scss
@@ -1,0 +1,330 @@
+// Simple Button
+//************************************************************************//
+// A bunch of extendable mixins to get the weird login buttons to work
+
+%btn {
+    @include button-size-edx($btn-padding-y, $btn-padding-x, $font-size-base, $border-radius);
+    @include button-variant($btn-primary-bg, $btn-primary-border);
+    @include transition($btn-transition);
+    color: $btn-primary-color;
+    display: inline-block;
+    height: auto;
+    font-weight: $btn-font-weight;
+    line-height: $btn-line-height;
+    text-align: center;
+    text-shadow: none;
+    text-decoration: none;
+    vertical-align: middle;
+    background-image: none;
+    border: $input-btn-border-width solid transparent;
+    box-shadow: none;
+    user-select: none;
+  
+    // Share hover and focus styles
+    &:focus,
+    &:hover,
+    &:hover:not(:disabled) {
+      background: lighten($btn-primary-bg, 5%) !important;
+      text-decoration: none;
+      outline: 0;
+      background-image: none;
+      box-shadow: $btn-focus-box-shadow;
+    }
+  
+    // Disabled comes first so active can properly restyle
+    &.disabled,
+    &:disabled {
+      @include box-shadow(none);
+      cursor: $cursor-disabled;
+      opacity: .65;
+    }
+  
+    &:active,
+    &.active {
+      @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);
+      background-image: none;
+    }
+  }
+  
+  %btn-flat {
+    @extend %btn;
+    @include button-variant($btn-primary-color, $btn-primary-border);
+    border: $input-btn-border-width solid $btn-primary-border;
+    color: $btn-primary-bg;
+  
+    // Share hover and focus styles
+    &:focus,
+    &:hover,
+    &:hover:not(:disabled) {
+      background-color: lighten($btn-primary-bg, 5%) !important;
+      color: $btn-primary-color;
+    }
+  }
+  
+  // selector damned for new post and reply buttons in discussion forum
+  %btn-forum {
+    @extend %btn;
+    border: none;
+    height: auto;
+    line-height: 1.5;
+  
+    .button-text {
+      color: $white;
+    }
+  
+    &:link,
+    &:hover,
+    &:active,
+    &:focus {
+      @extend %btn;
+      border: none;
+      height: auto;
+      line-height: 1.5;
+      color: $white;
+    }
+  
+    &.btn-link:focus,
+    &.btn-link:hover {
+      background-color: $main-color !important;
+    }
+  }
+  
+  
+  a.btn,
+  a:link.btn,
+  // button\,
+  button[type="submit"],
+  input[type="submit"],
+  input[type="button"],
+  .btn-outline-primary,
+  .view-teams .btn-secondary,
+  .view-teams .action-primary.action {
+    @extend %btn;
+  }
+  
+  .wrapper-downloads a.btn:hover:hover:link,
+  .view-teams .btn-secondary:hover:not(:disabled):hover {
+    color: $btn-primary-bg;
+  }
+  
+  a.btn-flat {
+    @extend %btn-flat;
+  }
+  
+  // # Login and register buttons
+  .header-global .nav-courseware li .btn,
+  .header-global .nav-courseware div .btn,
+  .view-survey .action-primary {
+    @extend %btn;
+  }
+  
+  .view-login,
+  .view-register,
+  .view-passwordreset,
+  .view-survey {
+    .form-actions button[type="submit"] {
+      @extend %btn;
+    }
+  }
+  
+  .login,
+  .register,
+  .passwordreset,
+  #forgot-password-modal #password-reset {
+    .form-actions button[type="submit"] {
+      @extend %btn;
+    }
+  
+    // third party auth
+    .form-actions.form-third-party-auth button[type="submit"] {
+      @extend %btn-flat;
+    }
+  
+    // go to login-register
+    a.btn.login-register {
+      @extend %btn-flat;
+      display: block;
+    }
+  }
+  
+  // Dashboard
+  // .sga-block .upload button,
+  // .action .button,
+  // .sga-block .upload button,
+  // .action button,
+  // .login-register .action-primary,
+  // .dashboard .my-courses .course .wrapper-messages-primary .message.message-status.course-status-certavailable .actions-primary .action-certificate .btn,
+  // .dashboard-banner .wrapper-msg .msg.has-actions .donate-actions .action-donate,
+  // .financial-assistance-wrapper .financial-assistance-form .action-primary,
+  // .verification-process .action-primary-blue,
+  // .verification-process .carousel .wrapper-task .controls .control .action,
+  // .verification-process .carousel .wrapper-task .msg .list-actions .action-retakephotos a,
+  // .verification-process .carousel #wrapper-review .review-task-name .list-actions .action-editname a,
+  // .verification-process.step-select-track .register-choice-audit .action-select input,
+  // .verification-process.step-confirmation .course-info .options .action-course,
+  // .verification-process.step-confirmation .course-info .course-actions .action-dashboard,
+  // .reverify-blocked .action-primary,
+  // .empty-dashboard-message a,
+  // .wrapper-msg.wrapper-auto-cert .auto-cert-message .has-actions .msg-actions .btn {
+  //   @extend %btn;
+  //   span,
+  //   .show-label,
+  //   .button-text {
+  //     color: $white;
+  //     font-weight: normal;
+  //   }
+  // }
+  
+  // Dashboard
+  .search-bar {
+    .search-button,
+    .cancel-button {
+      @extend %btn;
+  
+      &:hover {
+        line-height: $btn-line-height;
+        padding: $btn-padding-y $btn-padding-x;
+      }
+    }
+  
+    .cancel-button {
+      display: none;
+    }
+  }
+  
+  .dashboard {
+  
+    .my-courses .course {
+      .details .enter-course {
+        @extend %btn;
+      }
+  
+      .wrapper-messages-primary .message {
+        &.message-upsell .action-upgrade {
+          @extend %btn;
+        }
+  
+        &.message-status.course-status-certavailable .actions-primary .action-certificate .btn {
+          @extend %btn-flat;
+        }
+      }
+    }
+  
+    .empty-dashboard-message a {
+      @extend %btn;
+    }
+  
+  }
+  
+  .search-results .search-load-next {
+    @extend %btn;
+    display: block;
+  }
+  
+  
+  // Courses
+  .find-courses .discovery-submit {
+    @extend %btn;
+  }
+  
+  .courses-container .courses .course .course-image .cover-image .learn-more {
+    @extend %btn;
+  }
+  
+  // Courseware
+  
+  .xmodule_display.xmodule_CapaModule div.problem .action button {
+    @extend %btn;
+  
+    &.problem-action-btn {
+      max-width: 180px !important; // trick for spanish text
+      background-color: $btn-primary-bg;
+    }
+  }
+  
+  .courseware-bookmarks-button .bookmarks-list-button {
+    @extend %btn-flat;
+    padding: 5px 10px;
+    font-size: 13px;
+    line-height: 22px;
+  }
+  
+  .discussion-module .discussion-show {
+    @extend %btn-flat;
+  
+    &:focus,
+    &:hover,
+    &:hover:not(:disabled) {
+      color: $btn-primary-color !important;
+      background-color: $btn-primary-bg !important;
+      border: $input-btn-border-width solid $btn-primary-border !important;
+    }
+  }
+  
+  // settings
+  .account-settings-sections .section .account-settings-section-body .u-field .field button.u-field-link {
+    @extend %btn-flat;
+  }
+  
+  .account-settings-sections a.u-field-link span {
+    color: $btn-primary-color;
+  }
+  
+  // For the thread initiator only. TODO: get a discussion going and test the other buttons
+  .discussion .course-tabs .right,
+  .discussion-module,
+  .forum-new-post-form,
+  .discussion-submit-post {
+    .new-post-btn,
+    .control-button,
+    .submit,
+    .new-post-btn {
+      @extend %btn-forum;
+    }
+  }
+  .container,
+  .outside-app,
+  .wrapper-account-settings {
+    .discussion-body,
+    .discussion-module,
+    .discussion-user-threads {
+      .discussion-submit-post {
+        @extend %btn-forum;
+      }
+    }
+  }
+  .discussion,
+  .discussion-module,
+  .discussion-user-threads {
+    .comments .comment-form .discussion-submit-comment {
+      @extend %btn-forum;
+    }
+  }
+  .view-profile {
+    .wrapper-profile-sections,
+    .profile-self .wrapper-profile-field-account-privacy .u-field-account_privacy {
+      .discussion-body,
+      .discussion-module,
+      .discussion-user-threads {
+        .discussion-submit-post {
+          @extend %btn-forum;
+        }
+      }
+    }
+  }
+  
+  // Search button in discussion tab
+  
+  .discussion .forum-search .search-input {
+    margin: 2px;
+    padding: 0.4rem;
+  }
+  
+  #expand-collapse-outline-all-button {
+    @extend %btn;
+  }
+  
+  .login-register .login-provider {
+    width: 50%;
+  }
+  

--- a/edx-platform/bragi-children/espol/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/bragi-children/espol/lms/static/sass/partials/lms/theme/_extras.scss
@@ -1,0 +1,6 @@
+
+@import 'variables-extras';
+// Using the generic bragi
+@import '../../../../../../../../bragi/lms/static/sass/partials/lms/theme/bragi';
+@import 'buttons';
+

--- a/edx-platform/bragi-children/espol/lms/static/sass/partials/lms/theme/_variables-extras.scss
+++ b/edx-platform/bragi-children/espol/lms/static/sass/partials/lms/theme/_variables-extras.scss
@@ -1,0 +1,55 @@
+// BASE VARIABLES
+// =============================================
+
+// // set defaoult bacgrounds in login, register and password restes pages
+// $login-banner-image: '' !default;
+// $register-banner-image: '' !default;
+// $passwordreset-banner-image: '' !default;
+
+$main-color: #001c43;
+$font-family-base: OpenSans-Regular, Open Sans, sans-serif;
+
+$btn-transition: color 0.25s ease-in-out,background 0.25s ease-in-out,box-shadow 0.25s ease-in-out !important;
+// Navbar
+$navbar-bg: $white !default;
+$navbar-zindex: 1100 !default;
+$navbar__nav-login-color: $white !default;
+$navbar__nav-login-hover-color: $white !default;
+$navbar__nav-login-bg: $main-color;
+$navbar__nav-login-hover-bg: lighten($main-color, 5%);
+$navbar__nav-account-color: $main-color;
+$navbar__nav-account-border: 1px solid $main-color;
+$navbar__nav-toggler-color: $main-color;
+$navbar__nav-toggler-hover-bg: rgba(0, 0, 0, .05);
+$navbar__nav-link-color: $main-color;
+
+//Links color
+$link-color: $main-color;
+$link-hover-color: darken($link-color, 15%);
+
+$headings-font-family: $font-family-base;
+
+$h1-font-size: 2.5rem;
+$h2-font-size: 2rem;
+$h3-font-size: 1.75rem;
+$h4-font-size: 1.5rem;
+$h5-font-size: 1.25rem;
+$h6-font-size: 1rem;
+
+// Home
+$home-header__title-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12) !default;
+
+// Course
+$course-header__title-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12) !default;
+
+$course-component__item-more-color: $white !default;
+$course-component__item-more-bg: $main-color !default;
+$course-component__item-shadow: 0 3px 4px 0 rgba(0,0,0,.14),0 3px 3px -2px rgba(0,0,0,.2),0 1px 8px 0 rgba(0,0,0,.12) !default;
+$course-component__item-shadow--hover: 0 8px 10px 1px rgba(0,0,0,.14),0 3px 14px 2px rgba(0,0,0,.12),0 5px 5px -3px rgba(0,0,0,.2) !default;
+
+$course-component__item-more__span-color: $white !default;
+$course-component__item-more__span-border: $white !default;
+
+// Footer
+$footer-bg: $white !default;
+$footer-zindex: 1100 !default;

--- a/edx-platform/bragi-children/espol/lms/templates/courseware/course_about_sidebar.html
+++ b/edx-platform/bragi-children/espol/lms/templates/courseware/course_about_sidebar.html
@@ -1,0 +1,200 @@
+<%namespace name='static' file='/static_content.html'/>
+
+<%!
+from django.utils.translation import ugettext as _
+from django.urls import reverse
+from django.conf import settings
+from lms.djangoapps.courseware.courses import get_course_about_section
+from six import text_type, string_types
+%>
+
+<div class="course-summary">
+  <div class="main-cta text-center">
+    %if user.is_authenticated and registered:
+      %if show_courseware_link:
+      <a class="btn" href="${course_target}">
+      %endif
+
+      <span class="register disabled">${_("You are enrolled in this course")}</span>
+
+      %if show_courseware_link:
+        <strong>${_("View Course")}</strong>
+        </a>
+      %endif
+
+    % elif is_course_full:
+      <span class="register disabled">
+        ${_("Course is full")}
+      </span>
+    % elif invitation_only and not can_enroll:
+      <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
+      ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
+      ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click
+      ## so that they can register and become a real user that can enroll.
+    % elif not is_shib_course and not can_enroll:
+      <span class="register disabled">${_("Enrollment is Closed")}</span>
+    %elif allow_anonymous:
+      %if show_courseware_link:
+        <a href="${course_target}">
+          <strong>${_("View Course")}</strong>
+        </a>
+      %endif
+    %else:
+      <%
+        if ecommerce_checkout:
+          reg_href = ecommerce_checkout_link
+        else:
+          reg_href="#"
+        if single_paid_mode:
+          href_class = "add-to-cart"
+        else:
+          href_class = "register"
+      %>
+      <a href="${reg_href}" class="btn ${href_class}">
+        ${_("Enroll")}
+      </a>
+      <div id="register_error"></div>
+    %endif
+  </div>
+
+  <header class="mt-4 mb-0">
+    % if static.get_value('course_about_show_social_links', True):
+      <div class="social-sharing">
+        <div class="sharing-message">${_("Share with friends and family!")}</div>
+        ## TODO: this should probably be an overrideable block,
+        ##       or something allowing themes to do whatever they
+        ##       want here (and on this whole page, really).
+          <%
+            site_domain = static.get_value('site_domain', settings.SITE_NAME)
+            platform_name = static.get_platform_name()
+
+            ## Translators: This text will be automatically posted to the student's
+            ## Twitter account. {url} should appear at the end of the text.
+            tweet_text = _("I just enrolled in {number} {title} through {account}: {url}").format(
+                number=course.number,
+                title=course.display_name_with_default_escaped,
+                account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
+                url=u"http://{domain}{path}".format(
+                    domain=site_domain,
+                    path=reverse('about_course', args=[text_type(course.id)])
+                )
+            ).replace(u" ", u"+")
+            tweet_action = u"http://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=tweet_text)
+
+            facebook_link = static.get_value('course_about_facebook_link', settings.PLATFORM_FACEBOOK_ACCOUNT)
+
+            email_subject = u"mailto:?subject={subject}&body={body}".format(
+                subject=_("Take a course with {platform} online").format(platform=platform_name),
+                body=_("I just enrolled in {number} {title} through {platform} {url}").format(
+                    number=course.number,
+                    title=course.display_name_with_default_escaped,
+                    platform=platform_name,
+                    url=u"http://{domain}{path}".format(
+                        domain=site_domain,
+                        path=reverse('about_course', args=[text_type(course.id)]),
+                    )
+                )
+            ).replace(u" ", u"%20")
+          %>
+          <a href="${tweet_action}" class="share">
+            <span class="icon fa fa-twitter" aria-hidden="true"></span><span class="sr">${_("Tweet that you've enrolled in this course")}</span>
+          </a>
+          <a href="${facebook_link}" class="share">
+            <span class="icon fa fa-thumbs-up" aria-hidden="true"></span><span class="sr">${_("Post a Facebook message to say you've enrolled in this course")}</span>
+          </a>
+          <a href="${email_subject}" class="share">
+            <span class="icon fa fa-envelope" aria-hidden="true"></span><span class="sr">${_("Email someone to say you've enrolled in this course")}</span>
+          </a>
+      </div>
+    % endif
+  </header>
+  <%block name="course_about_important_dates">
+  <ol class="important-dates">
+    <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default}</span></li>
+    % if not course.start_date_is_still_default:
+        <%
+            course_start_date = course.advertised_start or course.start
+        %>
+      <li class="important-dates-item">
+        <span class="icon fa fa-calendar" aria-hidden="true"></span>
+        <p class="important-dates-item-title">${_("Classes Start")}</p>
+        % if isinstance(course_start_date, string_types):
+            <span class="important-dates-item-text start-date">${course_start_date}</span>
+        % else:
+            <%
+               course_date_string = course_start_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+            %>
+            <span class="important-dates-item-text start-date localized_datetime" data-format="shortDate" data-datetime="${course_date_string}" data-language="${LANGUAGE_CODE}"></span>
+        % endif
+      </li>
+    % endif
+      ## We plan to ditch end_date (which is not stored in course metadata),
+      ## but for backwards compatibility, show about/end_date blob if it exists.
+      % if course.end:
+          <%
+              course_end_date = course.end
+          %>
+
+      <li class="important-dates-item">
+          <span class="icon fa fa-calendar" aria-hidden="true"></span>
+          <p class="important-dates-item-title">${_("Classes End")}</p>
+            % if isinstance(course_end_date, string_types):
+                <span class="important-dates-item-text final-date">${course_end_date}</span>
+            % else:
+              <%
+                  course_date_string = course_end_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+              %>
+              <span class="important-dates-item-text final-date localized_datetime" data-format="shortDate" data-datetime="${course_date_string}" data-language="${LANGUAGE_CODE}"></span>
+            % endif
+      </li>
+      % endif
+
+    % if get_course_about_section(request, course, "effort"):
+      <li class="important-dates-item"><span class="icon fa fa-pencil" aria-hidden="true"></span><p class="important-dates-item-title">${_("Estimated Effort")}</p><span class="important-dates-item-text effort">${get_course_about_section(request, course, "effort")}</span></li>
+    % endif
+
+    ##<li class="important-dates-item"><span class="icon fa fa-clock-o" aria-hidden="true"></span><p class="important-dates-item-title">${_('Course Length')}</p><span class="important-dates-item-text course-length">${_('{number} weeks').format(number=15)}</span></li>
+
+    % if pre_requisite_courses:
+    <% prc_target = reverse('about_course', args=[text_type(pre_requisite_courses[0]['key'])]) %>
+    <li class="prerequisite-course important-dates-item">
+      <span class="icon fa fa-list-ul" aria-hidden="true"></span>
+      <p class="important-dates-item-title">${_("Prerequisites")}</p>
+      ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
+      <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
+      <p class="tip">
+      ${Text(_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.")).format(
+        link_start=HTML('<a href="{}">').format(prc_target),
+        link_end=HTML('</a>'),
+        prc_display=pre_requisite_courses[0]['display'],
+      )}
+      </p>
+    </li>
+    % endif
+
+    % if get_course_about_section(request, course, "prerequisites"):
+      <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
+    % endif
+  </ol>
+  </%block>
+</div>
+
+## CourseTalk widget
+% if show_coursetalk_widget:
+  <div class="coursetalk-read-reviews">
+    <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
+  </div>
+% endif
+
+## For now, ocw links are the only thing that goes in additional resources
+% if get_course_about_section(request, course, "ocw_links"):
+  <div class="additional-resources">
+    <h1>${_("Additional Resources")}</h1>
+  </div>
+
+  <div>
+    ## "MITOpenCourseware" should *not* be translated
+    <h2 class="opencourseware">MITOpenCourseware</h2>
+       ${get_course_about_section(request, course, "ocw_links")}
+  </div>
+%endif

--- a/edx-platform/bragi-children/espol/lms/templates/header/navbar-not-authenticated.html
+++ b/edx-platform/bragi-children/espol/lms/templates/header/navbar-not-authenticated.html
@@ -1,0 +1,60 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/main.html' import="login_query"/>
+
+<%!
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from six import text_type
+
+from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
+%>
+
+<%
+  mktg_site_enabled = static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False))
+  courses_are_browsable = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
+  allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
+  can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
+  restrict_enroll_for_course = course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
+%>
+<nav aria-label=${_("Supplemental Links")}> 
+  <ul class="navbar-links navbar-nav d-none d-lg-flex flex-row align-items-center">
+         % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
+          <li class="nav-item mobile-nav-item">
+              <a class="nav-link px-2" href="/login${login_query()}">${_("Sign in")}  Estudiantes Admisiones</a>
+          </li>
+          % endif
+        % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
+          % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
+          <li class="nav-item mobile-nav-item">
+            <a class="nav-link px-2" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Sign in")}</a>
+          </li>
+          % else:
+            % if settings.FEATURES.get('ednx_custom_login_link', False):
+              <li class="nav-item mobile-nav-item">
+                <a class="nav-link px-2" href="${ settings.FEATURES.get('ednx_custom_login_link') }">${_("Sign in")} Estudiantes ESPOL</a>
+              </li>
+            % endif
+          % endif
+        % endif
+        % if not settings.FEATURES.get('ednx_navigation__disable_register', False):
+          <li class="nav-item mobile-nav-item">
+            % if settings.FEATURES.get('ednx_custom_register_link', False):
+              <a class="nav-link nav-login px-4 py-2" href="${ settings.FEATURES.get('ednx_custom_register_link') }">${_("Register Now")}</a>
+            % elif course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
+              <a class="nav-link nav-login px-4 py-2" href="${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}">${_("Register Now")}</a>
+            % elif should_redirect_to_authn_mfe:
+              <a class="nav-link nav-login px-4 py-2" href="${settings.AUTHN_MICROFRONTEND_URL}/register${login_query()}">${_("Register Now")}</a>
+            % else:
+              <a class="nav-link nav-login px-4 py-2" href="/register${login_query()}">${_("Register Now")}</a>
+            % endif
+          </li>
+        % endif
+  </ul>
+</nav>

--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -1,0 +1,276 @@
+<%page expression_filter="h" args="online_help_token"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+  import six
+  from six.moves.urllib.parse import quote
+  from django.conf import settings
+  from django.urls import reverse
+  from django.utils.translation import ugettext as _
+  from cms.djangoapps.contentstore import toggles
+  from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+  logo_image_studio = configuration_helpers.get_value('STUDIO_LOGO_URL', '')
+%>
+<div class="wrapper-header wrapper" id="view-top">
+  <header class="primary" role="banner">
+    <div class="wrapper wrapper-l">
+      <h1 class="branding">
+        <a class="brand-link" href="/">
+            % if logo_image_studio:
+                <img class="brand-image" src="${logo_image_studio}" alt="${settings.STUDIO_NAME}" />
+            % else:
+                <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
+            % endif
+            % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
+            <span class="font-italic"> <span class="tilted">|</span> EDGE</span>
+            % endif
+        </a>
+      </h1>
+      
+      % if context_course:
+      <%
+            course_key = context_course.id
+            url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
+            index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            videos_url = reverse('videos_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            course_info_url = reverse('course_info_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            settings_url = reverse('settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            grading_url = reverse('grading_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            tabs_url = reverse('tabs_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            certificates_url = ''
+            if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
+                certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
+
+      %>
+      <h2 class="info-course">
+        <span class="sr">${_("Current Course:")}</span>
+        <a class="course-link" href="${index_url}">
+          <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
+          <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
+        </a>
+      </h2>
+
+      <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
+        <h2 class="sr">${_("Course Navigation")}</h2>
+        <ol>
+          <li class="nav-item nav-course-courseware">
+            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Content")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-course-courseware-outline">
+                    <a href="${index_url}">${_("Outline")}</a>
+                  </li>
+                  <li class="nav-item nav-course-courseware-updates">
+                    <a href="${course_info_url}">${_("Updates")}</a>
+                  </li>
+                  <li class="nav-item nav-course-courseware-pages">
+                    <a href="${tabs_url}">${_("Pages")}</a>
+                  </li>
+                  <li class="nav-item nav-course-courseware-uploads">
+                    <a href="${assets_url}">${_("Files & Uploads")}</a>
+                  </li>
+                  <li class="nav-item nav-course-courseware-textbooks">
+                    <a href="${textbooks_url}">${_("Textbooks")}</a>
+                  </li>
+                  % if context_course.video_pipeline_configured:
+                  <li class="nav-item nav-course-courseware-videos">
+                    <a href="${videos_url}">${_("Video Uploads")}</a>
+                  </li>
+                  % endif
+                </ul>
+              </div>
+            </div>
+          </li>
+
+          <li class="nav-item nav-course-settings">
+            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Course")} </span>${_("Settings")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-course-settings-schedule">
+                    <a href="${settings_url}">${_("Schedule & Details")}</a>
+                  </li>
+                  <li class="nav-item nav-course-settings-grading">
+                    <a href="${grading_url}">${_("Grading")}</a>
+                  </li>
+                  <li class="nav-item nav-course-settings-team">
+                    <a href="${course_team_url}">${_("Course Team")}</a>
+                  </li>
+                  <li class="nav-item nav-course-settings-group-configurations">
+                    <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': six.text_type(course_key)})}">${_("Group Configurations")}</a>
+                  </li>
+                  % if course_authoring_microfrontend_url:
+                  <li class="nav-item nav-course-settings-exams">
+                    <a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_key}">${_("Proctored Exam Settings")}</a>
+                  </li>
+                  % endif
+                  <li class="nav-item nav-course-settings-advanced">
+                    <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
+                  </li>
+                  % if certificates_url:
+                  <li class="nav-item nav-course-settings-certificates">
+                    <a href="${certificates_url}">${_("Certificates")}</a>
+                  </li>
+                  % endif
+                  % if frontend_app_publisher_url:
+                  <li class="nav-item nav-course-courseware-videos">
+                    <a href="${frontend_app_publisher_url}/course-runs/${url_encoded_course_key}">${_("Publisher")}</a>
+                  </li>
+                  % endif
+                </ul>
+              </div>
+            </div>
+          </li>
+
+          <li class="nav-item nav-course-tools">
+            <h3 class="title"><span class="label">${_("Tools")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-course-tools-import">
+                    <a href="${import_url}">${_("Import")}</a>
+                  </li>
+                  <li class="nav-item nav-course-tools-export">
+                    <a href="${export_url}">${_("Export")}</a>
+                  </li>
+                  % if toggles.EXPORT_GIT.is_enabled() and context_course.giturl:
+                  <li class="nav-item nav-course-tools-export-git">
+                    <a href="${reverse('export_git', kwargs=dict(course_key_string=six.text_type(course_key)))}">${_("Export to Git")}</a>
+                  </li>
+                  % endif
+                  <li class="nav-item nav-course-tools-checklists">
+                    <a href="${checklists_url}">${_("Checklists")}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </nav>
+      % elif context_library:
+       <%
+            library_key = context_library.location.course_key
+            index_url = reverse('library_handler', kwargs={'library_key_string': six.text_type(library_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': six.text_type(library_key)})
+            lib_users_url = reverse('manage_library_users', kwargs={'library_key_string': six.text_type(library_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': six.text_type(library_key)})
+      %>
+      <h2 class="info-course">
+        <span class="sr">${_("Current Library:")}</span>
+        <a class="course-link" href="${index_url}">
+          <span class="course-org">${context_library.display_org_with_default}</span><span class="course-number">${context_library.display_number_with_default}</span>
+          <span class="course-title" title="${context_library.display_name_with_default}">${context_library.display_name_with_default}</span>
+        </a>
+      </h2>
+
+      <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
+        <h2 class="sr">${_("Course Navigation")}</h2>
+        <ol>
+
+          <li class="nav-item nav-library-settings">
+            <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Library")} </span>${_("Settings")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-library-settings-team">
+                    <a href="${lib_users_url}">${_("User Access")}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+          <li class="nav-item nav-course-tools">
+            <h3 class="title"><span class="label">${_("Tools")}</span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
+
+            <div class="wrapper wrapper-nav-sub">
+              <div class="nav-sub">
+                <ul>
+                  <li class="nav-item nav-course-tools-import">
+                    <a href="${import_url}">${_("Import")}</a>
+                  </li>
+                  <li class="nav-item nav-course-tools-export">
+                    <a href="${export_url}">${_("Export")}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </nav>
+      % endif
+    </div>
+
+    <div class="wrapper wrapper-r">
+      % if header_language_selector_is_enabled():
+        <% languages = released_languages() %>
+        % if len(languages) > 1:
+        <nav class="user-language-selector" aria-label="${_('Language preference')}">
+          <form action="/i18n/setlang/" method="post" class="settings-language-form" id="language-settings-form">
+              <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
+              % if user.is_authenticated:
+              <input title="preference api" type="hidden" id="preference-api-url" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
+              % else:
+              <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+              % endif
+              <label><span class="sr">${_("Choose Language")}</span>
+              <select class="input select language-selector" id="settings-language-value" name="language">
+              % for language in languages:
+                % if language[0] == LANGUAGE_CODE:
+                 <option value="${language[0]}" selected="selected">${language[1]}</option>
+                % else:
+                 <option value="${language[0]}" >${language[1]}</option>
+                % endif
+              % endfor
+              </select>
+              </label>
+          </form>
+        </nav>
+      % endif
+      % endif
+      % if user.is_authenticated:
+      <nav class="nav-account nav-is-signedin nav-dd ui-right" aria-label="${_('Account')}">
+        <h2 class="sr-only">${_("Account Navigation")}</h2>
+        <ol>
+          % if settings.FEATURES.get('ENABLE_HELP_LINK'):
+            <li class="nav-item nav-account-help">
+              <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a></span></h3>
+            </li>
+          % endif
+          <li class="nav-item nav-account-user">
+            <%include file="user_dropdown.html" args="online_help_token=online_help_token" />
+          </li>
+        </ol>
+      </nav>
+
+    % else:
+      <nav class="nav-not-signedin nav-pitch" aria-label="${_('Account')}">
+        <h2 class="sr-only">${_("Account Navigation")}</h2>
+        <ol>
+          <li class="nav-item nav-not-signedin-help">
+            <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a>
+          </li>
+          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
+              <li class="nav-item nav-not-signedin-signup">
+                <a class="action action-signup" href="${settings.FRONTEND_REGISTER_URL}?next=${current_url}">${_("Sign Up")}</a>
+              </li>
+          % endif
+          <li class="nav-item nav-not-signedin-signin">
+            <a class="action action-signin" href="${settings.LOGIN_URL}?next=${current_url}">${_("Sign In")}</a>
+          </li>
+        </ol>
+      </nav>
+    % endif
+    </div>
+  </header>
+</div>


### PR DESCRIPTION

**Description**

This PR adds new bragi children for espol theme.

The changes are:

1. CMS static image (studio-logo.png)
2. Add 2 sign-in buttons (the first one redirect always to /login and the second one uses "ednx_custom_login_link" setting)
3. Add important dates in the course-about-sidebar.html
4. Change the base color (#001c43)

![163829855-f1648fd7-489a-4cbc-8f70-4d3df8a61f5c](https://user-images.githubusercontent.com/91694045/204036539-dac74819-83ff-42f3-a265-cebe4b68dce5.png)

**Note:**

1. To verify all theme changes add the config located [here](https://3.basecamp.com/3966315/buckets/22136261/todos/4815439041)

**How to test**

1. Use the stack-builder branch `dam/limonero-plugin` and the strain `limonerop`
2. Use the branch `dcoa/espol-theme`
3. Open a lms bash and run
`openedx-assets themes --theme-dirs /openedx/themes/ednx-saas-themes/edx-platform /openedx/themes/ednx-saas-themes/edx-platform/bragi-children --themes bragi-children/espol`
4. Create a tenant o microsite and add the configs (linked in note )
