### PR TITLE
feat: allow turn on/off edunext widget 

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/sock.html
+++ b/edx-platform/bragi/cms/templates/widgets/sock.html
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 %>
 
+% if getattr(settings,'EDUNEXT_HELP_SIDEBAR', False):
 
 <link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css?family=Poppins:400,700,900" rel="stylesheet">
@@ -90,3 +91,4 @@ from django.utils.translation import ugettext as _
   }
   if($('.action-item a[href*="Studio"]')[0]) $('.action-item a[href*="Studio"]').css('display', 'none')
 </script>
+% endif

--- a/edx-platform/bragi/lms/templates/main.html
+++ b/edx-platform/bragi/lms/templates/main.html
@@ -200,7 +200,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
   <%block name="footer_extra"/>
   <%block name="js_extra"/>
 
-  % if any('instructor_dashboard_2_html' in name[0]  for name in context.namespaces):
+  % if any('instructor_dashboard_2_html' in name[0]  for name in context.namespaces) and getattr(settings,'EDUNEXT_HELP_SIDEBAR', False):
         <%include file="widgets/help-sidebar.html" />
         <script type="text/javascript" src="${static.url('js/help-widget.js')}" charset="utf-8"></script>
   % endif


### PR DESCRIPTION
This PR allows turn on/off the eduNEXT widget (help-sidebar), by default is off.

**How to test**

- You can use stack-builder with a mango instance.
  **Note:** if you don´t use tutor-mfe you have to set this waffle flags `courseware.use_legacy_frontend` and `course_home.course_home_use_legacy_frontend` check context [here](https://discuss.openedx.org/t/disabling-the-learning-mfe-in-maple-slightly-misleading-documentation/6320)

- Use the branch `dcoa/optional-edunext-widget` in the theme folder.

- The widget is disabled by default.

- To enable the widget set a new config `"EDUNEXT_HELP_SIDEBAR": true`, you can use tenant configuration or general settings `lms.env.json - cms.env.json`

- Check the widget in the LMS Instructor tab, or in the CMS.

![184141059-2fd28d6f-c5b6-4585-8f38-9feb392a39af](https://user-images.githubusercontent.com/91694045/204039526-ec7b82c4-6d97-41db-8a9d-f82fb4c5333e.png)



![184183145-d3428062-cd25-422b-9ac7-3e8b6b57d3f0](https://user-images.githubusercontent.com/91694045/204039670-166bf7a8-5584-4231-945b-42f115eefc81.png)


