### PR TITLE
fix: modify rule styles for drag and drop component compatibility

### DIFF
--- a/edx-platform/bragi-generator/bragi-00695c/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-00695c/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-00838f/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-00838f/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-00897b/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-00897b/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-009688/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-009688/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-00acc1/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-00acc1/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-00bcd4/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-00bcd4/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-0277bd/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-0277bd/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-039be5/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-039be5/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-03a9f4/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-03a9f4/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-1565c0/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-1565c0/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-1e88e5/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-1e88e5/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-2196f3/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-2196f3/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-26a69a/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-26a69a/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-26c6da/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-26c6da/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-283593/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-283593/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-29b6f6/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-29b6f6/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-2e7d32/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-2e7d32/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-37474f/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-37474f/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-3949ab/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-3949ab/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-3f51b5/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-3f51b5/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-42a5f5/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-42a5f5/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-43a047/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-43a047/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-4527a0/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-4527a0/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-4caf50/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-4caf50/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-4e342e/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-4e342e/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-546e7a/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-546e7a/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-558b2f/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-558b2f/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-5c6bc0/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-5c6bc0/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-5e35b1/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-5e35b1/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-607d8b/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-607d8b/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-66bb6a/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-66bb6a/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-673ab7/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-673ab7/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-6a1b9a/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-6a1b9a/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-6d4c41/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-6d4c41/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-78909c/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-78909c/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-795548/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-795548/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-7cb342/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-7cb342/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-7e57c2/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-7e57c2/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-8bc34a/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-8bc34a/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-8d6e63/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-8d6e63/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-8e24aa/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-8e24aa/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-9c27b0/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-9c27b0/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-9ccc65/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-9ccc65/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-9e9d24/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-9e9d24/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ab47bc/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ab47bc/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ad1457/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ad1457/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-c0ca33/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-c0ca33/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-c62828/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-c62828/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-cddc39/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-cddc39/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-d4e157/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-d4e157/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-d81b60/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-d81b60/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-d84315/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-d84315/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-e53935/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-e53935/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-e91e63/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-e91e63/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ec407a/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ec407a/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ef5350/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ef5350/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ef6c00/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ef6c00/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-f44336/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-f44336/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-f4511e/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-f4511e/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-f9a825/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-f9a825/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-fb8c00/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-fb8c00/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-fdd835/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-fdd835/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ff5722/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ff5722/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ff7043/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ff7043/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ff8f00/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ff8f00/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ff9800/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ff9800/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ffa726/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ffa726/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ffb300/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ffb300/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ffc107/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ffc107/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ffca28/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ffca28/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ffeb3b/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ffeb3b/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi-generator/bragi-ffee58/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-generator/bragi-ffee58/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }

--- a/edx-platform/bragi/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi/lms/static/sass/partials/lms/theme/_course.scss
@@ -574,7 +574,7 @@ a.ui-slider-handle {
 .problems-wrapper,
 .xblock-student_view-problem.xmodule_display,
 .choicegroup.capa_inputtype,
-.problem div:not([id*="answer"]) {
+.problem div:not([id*="answer"], .drag-container, .drag-container *) {
   background-color: $white;
   box-shadow: none;
 }


### PR DESCRIPTION
### Fix drag and drop white 

Due to a change in the HTML tags hierarchy a custom CSS rule affects the drag-and-drop xblock styles.  
*Before* problem and drag-container have the same level.
![drag_drop_before](https://user-images.githubusercontent.com/66016493/212566290-53dbe9cb-74e9-4077-9d29-f9e20f244cb6.png)

*Now* drag-container is a child of problem. 
![drag_and_drop_now](https://user-images.githubusercontent.com/66016493/212566368-8abc604b-80e1-4396-b309-df76a50919b7.png)

## How to test
1. Use this branch in the theme folder.
2. If you are in dev mode compile the css files with `openedx-assets themes --theme-dirs /openedx/themes/ednx-saas-themes/edx-platform --themes bragi` command.
3. Create a course with a drag an drop component and check the LMS. 

**Result**
![image](https://user-images.githubusercontent.com/66016493/212566975-f86d223e-9b27-44db-843f-139555036b65.png)


**Context**
[JIRA Card](https://edunext.atlassian.net/browse/DS-386)

