### PR TITLE
fix: render Google Analytics at the end of the HTML

### DIFF
--- a/edx-platform/bragi/lms/templates/main.html
+++ b/edx-platform/bragi/lms/templates/main.html
@@ -145,7 +145,6 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 
   <meta name="openedx-release-line" content="${RELEASE_LINE}" />
 
-<%include file="google_analytics.html" />
 
 <% branch_key = static.get_value("BRANCH_IO_KEY", settings.BRANCH_IO_KEY) %>
 % if branch_key and not is_from_mobile_app:
@@ -228,6 +227,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
       % endif
     % endfor
   % endif
+<%include file="google_analytics.html" />
 </body>
 </html>
 


### PR DESCRIPTION
This PR translates the Google Analytics code to the bottom of the HTML with the purpose to avoid render errors with the youtube videos. 

**How to test**
- Use this branch in the theme folder.
- Create a course with a youtube video (you can use demo course from tutor `tutor local importdemocourse`).
- Add `EDNX_ENABLE_GOOGLE_ANALYTICS: true` to the `FEATURES` in the tenant config. 
- Check the script is in the bottom of the HTML (inside body instead of head tag) and you can see the video in the screen. 


**Evidence**
![image](https://user-images.githubusercontent.com/66016493/213580530-0a0f20b3-eb57-4fad-bcce-fa19b228cd43.png)

**Context** 
[First video on lesson don’t work](https://discuss.openedx.org/t/first-video-on-lesson-dont-work/3836)
[JIRA-CARD](https://edunext.atlassian.net/browse/DS-387)
