### PR TITLE
feat: migrate templates to olive

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -6,6 +6,7 @@
   from django.conf import settings
   from django.urls import reverse
   from django.utils.translation import gettext as _
+  from urllib.parse import quote_plus
   from cms.djangoapps.contentstore import toggles
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
   from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -262,7 +263,7 @@
           </li>
           % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
               <li class="nav-item nav-not-signedin-signup">
-                <a class="action action-signup" href="${settings.FRONTEND_REGISTER_URL}?next=${current_url}">${_("Sign Up")}</a>
+                <a class="action action-signup" href="${settings.FRONTEND_REGISTER_URL}?next=${quote_plus(request.build_absolute_uri(settings.LOGIN_URL))}">${_("Sign Up")}</a>
               </li>
           % endif
           <li class="nav-item nav-not-signedin-signin">

--- a/edx-platform/bragi/lms/templates/dashboard.html
+++ b/edx-platform/bragi/lms/templates/dashboard.html
@@ -291,7 +291,12 @@ from common.djangoapps.student.models import CourseEnrollment
                 cert_status = cert_statuses.get(session_id)
                 can_refund_entitlement = entitlement and entitlement.is_entitlement_refundable()
                 partner_managed_enrollment = enrollment.mode == 'masters'
-                can_unenroll = False if partner_managed_enrollment else (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
+                # checks if we can unenroll based on the value of partner_managed_enrollment
+                can_unenroll_partner_managed_enrollment = False if partner_managed_enrollment else (not cert_status)
+                # checks if we can unenroll based on the value of unfulfilled_entitlement
+                can_unenroll_unfulfilled_entitlement = cert_status.get('can_unenroll') if cert_status and not unfulfilled_entitlement else False
+                # compares the three different parameters by which we can unenroll
+                can_unenroll = (can_unenroll_partner_managed_enrollment or can_unenroll_unfulfilled_entitlement) and not disable_unenrollment                
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)
@@ -301,7 +306,7 @@ from common.djangoapps.student.models import CourseEnrollment
                 show_consent_link = (session_id in consent_required_courses)
                 resume_button_url = resume_button_urls[dashboard_index]
               %>
-              <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_voucher_refundable=is_course_voucher_refundable, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, partner_managed_enrollment=partner_managed_enrollment' />
+              <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment,enrollments_fbe_is_on=enrollments_fbe_is_on, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, is_course_voucher_refundable=is_course_voucher_refundable, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, partner_managed_enrollment=partner_managed_enrollment' />
             % endfor
           </ul>
         % else:


### PR DESCRIPTION
### This PR update Bragi templates according to olive new openedx release. 

#### How to test

- Be sure you have eox-tenant and eox-theming in your environment. 
- Clone the repo in `env/build/openedx/themes` and be sure use the current branch `dcoa/migration-to-olive`

- Add this line in `env/build/openedx/settings/lms/assets.py` and `env/build/openedx/settings/cms/assets.py `

```python
COMPREHENSIVE_THEME_DIRS.extend(['/openedx/themes/ednx-saas-themes/edx-platform', '/openedx/themes/ednx-saas-themes/edx-platform/bragi-children', '/openedx/themes/ednx-saas-themes/edx-platform/bragi-generator'])```
```

- Add these lines to **env/build/openedx/Dockerfile** in line 190

```dockerfile

# after line => RUN openedx-assets themes \

    --theme-dirs /openedx/themes/ednx-saas-themes/edx-platform /openedx/themes/ednx-saas-themes/edx-platform/bragi-children /openedx/themes/ednx-saas-themes/edx-platform/bragi-generator \
    --themes bragi \
# before line => && openedx-assets collect --settings=tutor.assets \
```

- In the `lms.env.yml `and `cms.env.yml` be sure to add:

```yml
USE_EOX_TENANT: True
DEFAULT_SITE_THEME: "bragi"
COMPREHENSIVE_THEME_DIRS: ["/openedx/themes/ednx-saas-themes/edx-platform/bragi-generator", "/openedx/themes/ednx-saas-themes/edx-platform/bragi-children", "/openedx/themes/ednx-saas-themes/edx-platform"]

```
- Now you can run stack strain dev init and stack strain dev start
- Open bash and compile bragi theme, [context](https://github.com/eduNEXT/tutor-contrib-edunext-distro#how-to-add-a-theme)

```
source .tvm/bin/activate
tutor dev run lms bash
# Inside the lms bash 
openedx-assets themes --theme-dirs /openedx/themes/ednx-saas-themes/edx-platform --themes bragi
```

Now you can see the default bragi theme applied in all LMS and any error about mako templates.


More Context 
[Jira Issue ](https://edunext.atlassian.net/browse/DS-372)

**Advance customize bragi evidence**
![image](https://user-images.githubusercontent.com/66016493/216300448-4b383b5e-c704-4ff6-9fd0-d7024c149a6e.png)

