### PR TITLE
fix: add jquery file upload from statics

### DIFF
--- a/edx-platform/bragi/lms/templates/head-extra.html
+++ b/edx-platform/bragi/lms/templates/head-extra.html
@@ -23,9 +23,11 @@ from django.utils.translation import get_language_bidi
     style_overrides_file = ''
 %>
 
+% if '/courseware/' in request.path:
 <script type="text/javascript" src="${static.url(fileupload_js_path)}"></script>
-
 <script type="text/javascript" src="${static.url(ifreme_js_path)}"></script>
+% endif
+
 
 % if style_overrides_file:
   <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file)}" />


### PR DESCRIPTION
**Description Bug**
The files which have the function to manage SGA logic weren't loading in LMS.

**Solution**
Create a reference in `head-extra.html` file.

**How to test**
- Use Bragi in your environment.
- Oper your site in the browser.
- Open the development tools and search for `jquery.fileupload.js` and `jquery.iframe-transport.js`, this files should be added to the head tag in the HTML. 

**Additional Information**
[JIRA-CARD](https://edunext.atlassian.net/browse/DS-389)