### PR TITLE
fix: separate the lang selector from the header link DS-515

### DIFF
--- a/edx-platform/bragi/lms/templates/header/header.html
+++ b/edx-platform/bragi/lms/templates/header/header.html
@@ -41,14 +41,13 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
         </div>
 
         <div class="container-navbar-links">
-          <ul class="navbar-links navbar-nav d-none d-lg-flex flex-row align-items-center">
+          <ul class="navbar-links navbar-nav d-none d-lg-flex flex-row align-items-center">    
+          %if header_langselector:
+          <div class="mx-3">
+            <%include file="../lang_selector.html"/>
+          </div>
+          %endif
           %if header_links:
-            %if header_langselector:
-            <div class="mx-3">
-              <%include file="../lang_selector.html"/>
-            </div>
-            %endif
-
             %for link in header_links:
              <li class="mobile-nav-item nav-item ${link.get('class', '') | h}">
               %if link.get('txt'):


### PR DESCRIPTION
### Description
Make the header_langselector variable independent of the header_links variable

### How to test
- start a tvm project
- clone distro
`pip install git+https://github.com/eduNEXT/tutor-contrib-edunext-distro`
`tutor plugins enable-distro`
`tutor config save`
`tutor distro enable-themes`
`tutor dev launch`
`tutor dev do createuser --superuser --staff admin admin@edunext.co`

### To replicate the bug
- Tenant configs -> Lms configs
`{
    "EDNX_USE_SIGNAL": true,
    "header_langselector": true,
    "released_languages": "en,ar"
}`
On the LMS site it will not appear in the lang selector

###  How to test the solution
`git checkout LFC/DS-515-lang-selector-issue`

The lang selector will appear on the LMS site:
![Captura desde 2023-05-09 11-09-16](https://github.com/eduNEXT/ednx-saas-themes/assets/78836902/6149ec97-1c75-40be-9c86-c3585f6b7364)
