### PR TITLE
fix: separate the lang selector from the header link

### DIFF
--- a/edx-platform/bragi/lms/templates/header/header.html
+++ b/edx-platform/bragi/lms/templates/header/header.html
@@ -41,14 +41,13 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
         </div>
 
         <div class="container-navbar-links">
-          <ul class="navbar-links navbar-nav d-none d-lg-flex flex-row align-items-center">
+          <ul class="navbar-links navbar-nav d-none d-lg-flex flex-row align-items-center">    
+          %if header_langselector:
+          <div class="mx-3">
+            <%include file="../lang_selector.html"/>
+          </div>
+          %endif
           %if header_links:
-            %if header_langselector:
-            <div class="mx-3">
-              <%include file="../lang_selector.html"/>
-            </div>
-            %endif
-
             %for link in header_links:
              <li class="mobile-nav-item nav-item ${link.get('class', '') | h}">
               %if link.get('txt'):


### PR DESCRIPTION
This PR is intended to separate the lang selector from the header link.