### PR TITLE
fix: set right classes on rtl view

### DIFF
--- a/edx-platform/bragi/lms/templates/courseware/course_about.html
+++ b/edx-platform/bragi/lms/templates/courseware/course_about.html
@@ -143,7 +143,7 @@ from six import string_types
           <div>${get_course_about_section(request, course, 'short_description')}</div>
         </div>
 
-        <div class="main-cta ml-2 col-md-3 text-center">
+        <div class="main-cta ${'mr-2' if LANGUAGE_BIDI else 'ml-2'} col-md-3 text-center">
           %if user.is_authenticated and registered:
             %if show_courseware_link:
               <a class="btn" href="${course_target}">
@@ -199,7 +199,7 @@ from six import string_types
 
     <div class="course-info__content row container mt-5 p-4">
 
-      <div class="details col col-12 mr-0">
+      <div class="details col col-12 ${'ml-0' if LANGUAGE_BIDI else 'mr-0'}">
         % if course_text_into_html:
           ${course_text_into_html | n, decode.utf8}
         % endif
@@ -349,8 +349,7 @@ from six import string_types
         <div class="col col-12 col-md-10">
           <h1 class="course-title d-flex mb-2">
             ${course.display_name_with_default_escaped}
-
-            <div class="main-cta ml-2 text-center">
+            <div class="main-cta ${'mr-2' if LANGUAGE_BIDI else 'ml-2'} text-center">
               %if user.is_authenticated and registered:
                 %if show_courseware_link:
                   <a class="btn" href="${course_target}">
@@ -412,7 +411,7 @@ from six import string_types
         <%include file="./course_about_sidebar.html" />
       </div>
 
-      <div class="details col col-12 col-lg-9 mr-0">
+      <div class="details col col-12 col-lg-9 ${'ml-0' if LANGUAGE_BIDI else 'mr-0'}">
         % if course_text_into_html:
           ${course_text_into_html | n, decode.utf8}
         % endif


### PR DESCRIPTION
## Description 

This allows to set the margin based on the orientation, I consider the following  like the first approach 

```
.ml-x {
  margin-left: 0.5rem;
}

:dir(rtl) .ml-x {
  margin-right: 0.5rem;
}

```

however it's not possible to change that since ml-2 is defined in an external dependency.

So  this changes the class name based on the orientation if  the view is rtl the class wil be` mr-x`  instead of `ml-x` that is the current behavior 

## Result

![image](https://github.com/eduNEXT/ednx-saas-themes/assets/36200299/aecd2f4b-9df9-4a63-afc2-c56e26c7f7df)

