### PR TITLE
Jlc/add iframe feedback nelp

### DIFF
--- a/edx-platform/bragi/lms/static/sass/partials/lms/theme/_home.scss
+++ b/edx-platform/bragi/lms/static/sass/partials/lms/theme/_home.scss
@@ -21,6 +21,18 @@ main.home > div:last-child {
   }
 }
 
+.home-feedback-courses-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  iframe {
+    min-height: 270px;
+    margin-top: 20px;
+    border: none;
+    height: 100%;
+    width: 100%;
+  }
+}
+
 /* ========================================================
    Downgrade path styles
 ======================================================== */

--- a/edx-platform/bragi/lms/templates/index.html
+++ b/edx-platform/bragi/lms/templates/index.html
@@ -148,6 +148,13 @@ from openedx.core.djangolib.markup import HTML, Text
       </div>
     % endif
   % endif
+  % if getattr(settings, 'HOME_SHOW_COURSES_FEEDBACK', False):
+    <section class="home-courses" >
+      <div class="home-feedback-courses-container" >
+        <iframe src="/eox-nelp/frontend/experience/feedback/courses" title="feedback courses carousel"></iframe>
+      </div>
+    </section>
+  % endif
 </main>
 
 <%block name="js_extra">


### PR DESCRIPTION
# Description
This adds the course experience component view from eox-nelp as an iframe on the home page.

This part is managed by the setting flag. `HOME_SHOW_COURSES_FEEDBACK`
By default is set to true.

## After
**html place**
![Peek 2023-06-27 15-00](https://github.com/eduNEXT/ednx-saas-themes/assets/51926076/5fb4c1df-c393-4e22-a566-76e26f5b9e4f)
**flag management**:
![Peek 2023-06-27 16-00](https://github.com/eduNEXT/ednx-saas-themes/assets/51926076/6a1fde46-a269-49bb-a295-a090a1a81377)
### extra info
deployed  in stage
![Peek 2023-06-27 16-19](https://github.com/eduNEXT/ednx-saas-themes/assets/51926076/9196642c-efe3-4ff7-a380-f55e2940c9fa)

### jira stories
https://edunext.atlassian.net/jira/software/c/projects/FUTUREX/boards/36?modal=detail&selectedIssue=FUTUREX-423
