### PR TITLE
DS-559 feat: Use txt prop from header_link conf for translation

### DIFF
--- a/edx-platform/bragi/lms/templates/header/header.html
+++ b/edx-platform/bragi/lms/templates/header/header.html
@@ -51,7 +51,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
             %for link in header_links:
              <li class="mobile-nav-item nav-item ${link.get('class', '') | h}">
               %if link.get('txt'):
-                <a class="nav-link px-2" href="${link.get('url', '#') | h}" target="${link.get('target', '_self') | h}">${link.get('txt') | h}</a>
+                <a class="nav-link px-2" href="${link.get('url', '#') | h}" target="${link.get('target', '_self') | h}">${_(link.get('txt')) | h}</a>
               %endif
              </li>
             %endfor


### PR DESCRIPTION
# Allow using txt prop from header_link conf for translation

## Description 
This PR has the intention of solving the issue [#154 from ednx-saas-themes](https://github.com/eduNEXT/ednx-saas-themes/issues/154) making bragi header able to use the txt property from header_link tenant configuration object as a msgid to recover the translation if it exist 

### Changes 
- Apply the underscore use of gettext for getting the translation using the txt prop as a msgid

### How to test 
I test this implementation with olive following the guides for reproduction in the description of the issue [#154](https://github.com/eduNEXT/ednx-saas-themes/issues/154#issue-1731061520) but applying some changes:

- Be sure you have eox-tenant and eox-theming in your environment.
- Clone the repo in `src/` and be sure to use the current branch `bc/addcoursetranslation`
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/ea2cc66b-732e-48f8-afb9-7671dd428598)

- Add this line `- '../../src/edxapp/ednx-saas-themes/edx-platform:/openedx/themes'` in the `docker-compose.override.yml` in `env/dev `
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/6c1d1d57-68ea-4888-9269-055b4fc2207e)

- In the `lms.env.yml` be sure to add `USE_EOX_TENANT: True`
- Now you can run the dev environment with `tutor dev start`

- Finally, create a tenant ensuring to have this configurations added:
```json
{
    "EDNX_USE_SIGNAL": true,
    "header_links": [
          {
              "class": "mx-2",
              # This txt word is in the translations
              "txt": "Courses",
              "url": "/courses"
          },
          {
              "class": "mx-2",
              # This is in the translations, too
              "txt": "Loading",
              "url": "/example1"
          },
          {
              "class": "mx-2",
              # This should not be translated
              "txt": "Otro",
              "url": "/otro"
          }
      ],
    "header_langselector": true,
    "released_languages": "ar,pt-BR,en-uk,es-419,fr,pl,it-IT"
}
```

- Add the same languages ( ar,pt-BR,en-uk,es-419,fr,pl,it-IT ) codes to your dark lang config table
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/b4b89584-0912-49cd-b194-3242ebadeb0d)

Now you can select a language in the dropdown and you'll see how the header links change according to the selected language; if is not found a translation for the txt prop value, then the txt value will be the value shown in the link 
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/f8951440-4230-4ed5-a75f-ab8621c053e3)
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/216f163b-2807-4464-a112-22febef1392e)

### Additional information 
[Jira card](https://edunext.atlassian.net/browse/DS-559?atlOrigin=eyJpIjoiOTllNDU4OTNjM2E5NDk3ZjhhMTZkYzcxYWMxMTczNmQiLCJwIjoiaiJ9) 