### PR TITLE
fix: pages and resources url for course authoring mfe

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -90,9 +90,11 @@
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${assets_url}">${_("Files & Uploads")}</a>
                   </li>
+                  % if not pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-textbooks">
                     <a href="${textbooks_url}">${_("Textbooks")}</a>
                   </li>
+                  % endif
                   % if context_course.video_pipeline_configured:
                   <li class="nav-item nav-course-courseware-videos">
                     <a href="${videos_url}">${_("Video Uploads")}</a>


### PR DESCRIPTION
Fix url to redirec to course authoring mfe,

To check this, please enable the `discussions.pages_and_resources_mfe `  flag in django admin

issue related: https://github.com/eduNEXT/ednx-saas-themes/issues/166

![fix-resources](https://github.com/eduNEXT/ednx-saas-themes/assets/134975835/a2b54bb5-074d-43af-a03a-2960626dfa7a)




