### PR TITLE
feat: add support to GA4 DS-577

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/google_analytics.html
+++ b/edx-platform/bragi/cms/templates/widgets/google_analytics.html
@@ -1,5 +1,8 @@
 ## This is the default for a microsite which does not have its own
 
+<%namespace name='static' file='../static_content.html'/>
+<%! from openedx.core.djangolib.js_utils import js_escaped_string %>
+
 % if settings.FEATURES.get('EDNX_ENABLE_GOOGLE_ANALYTICS', False):
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/edx-platform/bragi/lms/templates/google_analytics.html
+++ b/edx-platform/bragi/lms/templates/google_analytics.html
@@ -1,5 +1,8 @@
 ## This is the default for a microsite which does not have its own
 
+<%namespace name='static' file='static_content.html'/>
+<%! from openedx.core.djangolib.js_utils import js_escaped_string %>
+
 % if settings.FEATURES.get('EDNX_ENABLE_GOOGLE_ANALYTICS', False):
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Allow tracking data with GA4. To do so, we need to set: `GOOGLE_ANALYTICS_4_ID`.

Important note: This is still working as usual for the clients (tenants).

The inspiration for these changes comes from https://github.com/openedx/edx-platform/pull/32032

## How to test it

- Have a tutor env with eox-theming and this theme.
    - The easy way to do it is with distro and with this configs:
```
DEV_PROJECT_NAME: ga4_dev
LOCAL_PROJECT_NAME: ga4_local
DISTRO_THEMES_NAME:
  - bragi
DISTRO_THEME_DIRS:
  - "/openedx/themes/ednx-saas-themes/edx-platform/bragi-generator"
  - "/openedx/themes/ednx-saas-themes/edx-platform/bragi-children"
  - "/openedx/themes/ednx-saas-themes/edx-platform"
DISTRO_THEMES_ROOT: "/openedx/themes"
DISTRO_THEMES:
  - name: ednx-saas-themes
    repo: ednx-saas-themes
    version: mfmz/ga4
    domain: github.com
    protocol: ssh
    path: eduNEXT
DISTRO_EOX_THEMING_DPKG:
  index: git
  name: eox-theming
  repo: eox-theming
  domain: github.com
  path: eduNEXT
  protocol: https
  private: false
  variables:
    development:
      EOX_THEMING_CONFIG_SOURCES: [
        "from_eox_tenant_microsite_v2",
        "from_django_settings"
      ]
    production:
      EOX_THEMING_CONFIG_SOURCES: [
        "from_eox_tenant_microsite_v2",
        "from_django_settings"
      ]
  version: v5.0.0
DISTRO_EOX_TENANT_DPKG:
  index: git
  name: eox-tenant
  repo: eox-tenant
  domain: github.com
  path: eduNEXT
  protocol: https
  private: false
  variables:
    development:
      EOX_TENANT_USERS_BACKEND: eox_tenant.edxapp_wrapper.backends.users_l_v1
      EOX_TENANT_LOAD_PERMISSIONS: false
    production:
      EOX_TENANT_USERS_BACKEND: eox_tenant.edxapp_wrapper.backends.users_l_v1
      EOX_TENANT_LOAD_PERMISSIONS: false
  version: v8.0.0
OPENEDX_EXTRA_SETTINGS:
  cms_env: [
    USE_EOX_TENANT: true
  ]
  lms_env: [
    USE_EOX_TENANT: true,
    ENABLE_EOX_THEMING_DERIVE_WORKAROUND: true
  ]
```
(Run: tutor config save, tutor distro enable-themes, and tutor images build openedx)
- In env/apps/openedx/config/lms.env.yml add some string in `GOOGLE_ANALYTICS_4_ID` and `FEATURES["EDNX_ENABLE_GOOGLE_ANALYTICS"]=True`
- Run the platform and not fail.

### For deep test: 
- Add `<p>${static.get_value("GOOGLE_ANALYTICS_4_ID", settings.GOOGLE_ANALYTICS_4_ID)}</p>` in env/build/openedx/themes/ednx-saas-themes/edx-platform/bragi/lms/templates/google_analytics.html
- Reload with: `tutor dev exec lms reload-uwsgi`
- Search for the string you put in `GOOGLE_ANALYTICS_4_ID` in elements, in inspect, in your browser.
![Screenshot from 2023-07-18 21-44-46](https://github.com/eduNEXT/ednx-saas-themes/assets/35668326/ea6bdcea-27c3-4a47-bddd-7892640b435c)
