### PR TITLE
feat: making the color of the email button variable

### DIFF
--- a/edx-platform/bragi/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/edx-platform/bragi/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -120,7 +120,7 @@
                             {% get_action_links channel omit_unsubscribe_link=omit_unsubscribe_link as action_links %}
                             {% for action_link_url, action_link_text in action_links %}
                                 <p>
-                                    <a href="{{ action_link_url }}" style="color: #2f9fd8">
+                                    <a href="{{ action_link_url }}" style="color: {{ EMAIL_COLORS.email_button__background|default:"#2e9fd8" }}">
                                         <font color="{{ EMAIL_COLORS.email_button__background|default:"#2e9fd8" }}"><b>{{ action_link_text }}</b></font>
                                     </a>
                                 </p>


### PR DESCRIPTION
Hi team, I hope you all are doing great !!

This PR is intended to make the color of the emails button variable, this so that there is consistency with the colors that are placed when configuring these settings "email_button__color" and "email_button__background", since when configuring this setting in our tenants it remains as follows.

![Screenshot from 2023-08-17 22-47-57](https://github.com/eduNEXT/ednx-saas-themes/assets/105317492/2fce8f8d-b22f-4f6f-83ed-87d1a10f273d)

The code that is currently responsible for configuring these colors can be found below.

https://github.com/eduNEXT/ednx-saas-themes/blob/e7f864f869d3f26029081b5010629a5550fed47e/edx-platform/bragi/lms/templates/ace_common/edx_ace/common/return_to_course_cta.html#L21-L36

### How to test

1. Add the following setting in your site's tenant config.

``` json
"EMAIL_COLORS": {
    "email_button__background": "#000000",
    "email_button__color": "#ffffff"
}
```

2. Send emails from your site to test the button looks great.