### PR TITLE
Jlc/add nelp strain dispatcher

### DIFF
--- a/.github/workflows/nelp_strain_dispatcher.yml
+++ b/.github/workflows/nelp_strain_dispatcher.yml
@@ -15,7 +15,7 @@ jobs:
           echo "${BASH_VERSION}"
           echo "STRAIN_PROPERTY=${STRAIN_PROPERTY}" >> $GITHUB_ENV # update GitHub ENV vars
         env:
-          STRAIN_PROPERTY: DISTRO_THEME_DIRS[3].version
+          STRAIN_PROPERTY: DISTRO_THEMES[3].version
           BASE_REF: "${{ github.base_ref }}"
       - name: Strain Repository Dispatch
         if: |


### PR DESCRIPTION
# Description 
with this configuration is missing the pat configuration.

This action is supposed to run only for the branch that has the workflow because the HEAD branch has the action to run.
## Strain PR created
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/51926076/6c5d2303-8a57-425e-9efb-0954d3e3ae5a)
