### PR TITLE
refactor!: include template instead of iframe

### DIFF
--- a/edx-platform/bragi/lms/templates/nelc_extra_features.html
+++ b/edx-platform/bragi/lms/templates/nelc_extra_features.html
@@ -4,23 +4,22 @@ stats_settings = getattr(settings, 'STATS_SETTINGS', {})
 
 % if stats_settings.get('SHOW_HOME_CONTENT', False):
   <%
-  stats_query_params = ''
-  hidden_items = [
-    f'show_{key.lower()}=false'
-    for key, value in stats_settings.get('HIDDEN_HOME_STATS', {}).items()
-    if value == True
-  ]
-
-  if hidden_items:
-      stats_query_params = f"?{'&'.join(hidden_items)}"
+    tenant_stats = {
+      f'show_{key.lower()}': 'false' if value else 'true'
+      for key, value in stats_settings.get('HIDDEN_HOME_STATS', {}).items()
+    }
   %>
-  <section class="home-courses" >
-    <div class="tenant-stats-container" >
-      <iframe
-        src="/eox-nelp/stats/tenant/${stats_query_params}" title="tenant-stats">
-      </iframe>
-    </div>
-  </section>
+  <div class="tenant-stats-container" >
+    <%include file="tenant_stats.html" args="
+      show_videos=tenant_stats.get('show_videos', 'true'),
+      show_courses=tenant_stats.get('show_courses', 'true'),
+      show_problems=tenant_stats.get('show_problems', 'true'),
+      show_learners=tenant_stats.get('show_learners', 'true'),
+      show_instructors=tenant_stats.get('show_instructors', 'true'),
+      show_certificates=tenant_stats.get('show_certificates', 'true')"
+    />
+  </div>
+
 % endif
 
 % if getattr(settings, 'HOME_SHOW_COURSES_FEEDBACK', False):


### PR DESCRIPTION
## Description 
This loads the stats template instead of loading the stats view url into an iframe.

This is just compatible with the  eox-nelp versions that include this changes https://github.com/eduNEXT/eox-nelp/pull/97

## Result
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/36200299/9457ff25-ee6b-4a39-8937-d4a96b843289)

