### PR TITLE
feat: this allows to include a css extra file by using django settings

### DIFF
--- a/edx-platform/bragi/lms/templates/head-extra.html
+++ b/edx-platform/bragi/lms/templates/head-extra.html
@@ -1,12 +1,10 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-import colorsys
 from django.utils.translation import ugettext as _
 from django.utils.translation import get_language_bidi
 %>
 <%namespace name='static' file='static_content.html'/>
-<%interactive_color = theming.options('interactive_color') %>
 
 <%
   style_overrides_file = None
@@ -39,40 +37,4 @@ from django.utils.translation import get_language_bidi
   <style type="text/css">${style_overrides_inline_extra | n}</style>
 % endif
 
-% if interactive_color:
-
-  <%
-    main_color = interactive_color.lstrip('#')
-    r, g, b = tuple(int(main_color[i:i+2], 16) for i in (0, 2, 4))
-    h, l, s = colorsys.rgb_to_hls(r/255, g/255, b/255)
-
-    key = "--main-color"
-    colors = {}
-
-    def assign_alpha(colors, r, g, b):
-      for alpha in range(0, 11, 1):
-          alpha_key = f"{key}-alpha-{alpha}" if alpha != 10 else key
-          colors[alpha_key] = f"rgba({r}, {g}, {b}, {alpha/10})"
-
-    assign_alpha(colors, r, g, b)
-
-    for theme in  ["light", "dark"]:
-        if theme == "dark":
-            aux_func = lambda x: max(l - x/100, 0)
-        else:
-            aux_func = lambda x: min(l + x/100, 1)
-
-        for i in range(1, 100, 1):
-            key = f"--{theme}-color-lightness-{i}"
-            value = tuple([int(c*255) for c in colorsys.hls_to_rgb(h, aux_func(i), s)])
-            assign_alpha(colors, value[0], value[1], value[2])
-  %>
-
-  <style type="text/css">
-  :root {
-    % for k, v in colors.items():
-    ${k}: ${v};
-    % endfor
-  }
-  </style>
-% endif
+<%include file="nelc-head-extra.html"/>

--- a/edx-platform/bragi/lms/templates/nelc-head-extra.html
+++ b/edx-platform/bragi/lms/templates/nelc-head-extra.html
@@ -1,0 +1,53 @@
+<%page expression_filter="h"/>
+<%!
+import colorsys
+%>
+<%namespace name='static' file='static_content.html'/>
+<%interactive_color = theming.options('interactive_color') %>
+
+## External overrides, this replicates the master behavior however this allows to use Django settings instead of just tenant-config settings
+<%
+  style_overrides_file_extra = theming.options('CSS_OVERRIDES_FILE_EXTRA', default= False)
+%>
+
+% if style_overrides_file_extra:
+  <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file_extra)}" />
+% endif
+
+% if interactive_color:
+
+  <%
+    main_color = interactive_color.lstrip('#')
+    r, g, b = tuple(int(main_color[i:i+2], 16) for i in (0, 2, 4))
+    h, l, s = colorsys.rgb_to_hls(r/255, g/255, b/255)
+
+    key = "--main-color"
+    colors = {}
+
+    def assign_alpha(colors, r, g, b):
+      for alpha in range(0, 11, 1):
+          alpha_key = f"{key}-alpha-{alpha}" if alpha != 10 else key
+          colors[alpha_key] = f"rgba({r}, {g}, {b}, {alpha/10})"
+
+    assign_alpha(colors, r, g, b)
+
+    for theme in  ["light", "dark"]:
+        if theme == "dark":
+            aux_func = lambda x: max(l - x/100, 0)
+        else:
+            aux_func = lambda x: min(l + x/100, 1)
+
+        for i in range(1, 100, 1):
+            key = f"--{theme}-color-lightness-{i}"
+            value = tuple([int(c*255) for c in colorsys.hls_to_rgb(h, aux_func(i), s)])
+            assign_alpha(colors, value[0], value[1], value[2])
+  %>
+
+  <style type="text/css">
+  :root {
+    % for k, v in colors.items():
+    ${k}: ${v};
+    % endfor
+  }
+  </style>
+% endif


### PR DESCRIPTION
## Description
This includes multiple changes:
1. Moves NELC logic to an external file, so it easy to perform a migration
2. Allows to add an extra css file,current implementation doesn't allow to set that by Django settings

https://edunext.atlassian.net/browse/FUTUREX-530

## How to test

1. Set `CSS_OVERRIDES_FILE_EXTRA = "https://edx-platform-extra-ccs-and-js.s3.me-south-1.amazonaws.com/default_extra_styles.css"`  in your development settings (Django settings, don't use tenant config)
2. Go to the home page and verify