### PR TITLE
feat: make studio logo footer configurable

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/footer.html
+++ b/edx-platform/bragi/cms/templates/widgets/footer.html
@@ -1,0 +1,69 @@
+## mako
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import gettext as _
+from django.urls import reverse
+from datetime import datetime
+from django.conf import settings
+import pytz
+from cms.djangoapps.contentstore.config.waffle import ENABLE_ACCESSIBILITY_POLICY_PAGE
+from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+logo_footer_studio = configuration_helpers.get_value('LOGO_TRADEMARK_URL', '')
+redirect_footer_studio = configuration_helpers.get_value('LOGO_TRADEMARK_REDIRECT', '')
+%>
+
+<div class="wrapper-footer wrapper">
+  <footer class="primary" role="contentinfo">
+
+    <div class="footer-content-primary">
+      <div class="colophon">
+        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+      </div>
+
+        <nav class="nav-peripheral" aria-label="${_("Policies")}">
+          <ol>
+            % if is_marketing_link_set('TOS'):
+              <li class="nav-item nav-peripheral-tos">
+                <a href="${marketing_link('TOS')}">${_("Terms of Service")}</a>
+              </li>
+            % endif
+            % if is_marketing_link_set('PRIVACY'):
+              <li class="nav-item nav-peripheral-pp">
+                <a href="${marketing_link('PRIVACY')}">${_("Privacy Policy")}</a>
+              </li>
+            % endif
+            % if ENABLE_ACCESSIBILITY_POLICY_PAGE.is_enabled():
+              <li class="nav-item nav-peripheral-aar">
+                <a href="${reverse('accessibility')}">${_("Accessibility Accommodation Request")}</a>
+              </li>
+            %endif
+            <li class="nav-item">
+              <a id="lms-link" href="${settings.LMS_ROOT_URL}">${_("LMS")}</a>
+            </li>
+          </ol>
+        </nav>
+    </div>
+
+    <div class="footer-content-secondary" aria-label="${_("Legal")}">
+      <div class="footer-about-copyright">
+        ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+        <p>
+          ## Translators: 'edX' and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate any of these trademarks and company names.
+          ${Text(_("edX, Open edX, and the edX and Open edX logos are registered trademarks of {link_start}edX Inc.{link_end}")).format(
+            link_start=HTML(u"<a href='https://www.edx.org/'>"),
+            link_end=HTML(u"</a>")
+          )}
+        </p>
+      </div>
+      % if logo_footer_studio:
+      <div class="footer-about-openedx">
+        <a href="${redirect_footer_studio}">
+          <img alt="${_("Footer logo")}" src="${logo_footer_studio}">
+        </a>
+      </div>
+      % endif
+    </div>
+  </footer>
+</div>


### PR DESCRIPTION
This PR removes the default "Powered by Openedx" logo and leaves no logo by default. However, add LOGO_TRADEMARK_URL and LOGO_TRADEMARK_REDIRECT variables in case a logo is needed.  