### PR TITLE
perf: migrate Bragi to Quince

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -1,7 +1,6 @@
 <%page expression_filter="h" args="online_help_token"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-  import six
   from six.moves.urllib.parse import quote
   from django.conf import settings
   from django.urls import reverse
@@ -9,7 +8,7 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
   from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
@@ -31,36 +30,54 @@
             % endif
         </a>
       </h1>
-      
+
       % if context_course:
       <%
             course_key = context_course.id
-            url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
-            index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            videos_url = reverse('videos_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            import_url = reverse('import_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            course_info_url = reverse('course_info_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            export_url = reverse('export_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            settings_url = reverse('settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            grading_url = reverse('grading_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            tabs_url = reverse('tabs_handler', kwargs={'course_key_string': six.text_type(course_key)})
+            url_encoded_course_key = quote(str(course_key).encode('utf-8'), safe='')
+            index_url = reverse('course_handler', kwargs={'course_key_string': str(course_key)})
+            course_team_url = reverse('course_team_handler', kwargs={'course_key_string': str(course_key)})
+            assets_url = reverse('assets_handler', kwargs={'course_key_string': str(course_key)})
+            textbooks_url = reverse('textbooks_list_handler', kwargs={'course_key_string': str(course_key)})
+            videos_url = reverse('videos_handler', kwargs={'course_key_string': str(course_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': str(course_key)})
+            course_info_url = reverse('course_info_handler', kwargs={'course_key_string': str(course_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': str(course_key)})
+            settings_url = reverse('settings_handler', kwargs={'course_key_string': str(course_key)})
+            grading_url = reverse('grading_handler', kwargs={'course_key_string': str(course_key)})
+            advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': str(course_key)})
+            tabs_url = reverse('tabs_handler', kwargs={'course_key_string': str(course_key)})
             certificates_url = ''
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
-                certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
+                certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
+            checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
+            course_outline_mfe_enabled = toggles.use_new_course_outline_page(context_course.id)
+            updates_mfe_enabled = toggles.use_new_updates_page(context_course.id)
+            files_uploads_mfe_enabled = toggles.use_new_files_uploads_page(context_course.id)
+            video_upload_mfe_enabled = toggles.use_new_video_uploads_page(context_course.id)
+            schedule_details_mfe_enabled = toggles.use_new_schedule_details_page(context_course.id)
+            grading_mfe_enabled = toggles.use_new_grading_page(context_course.id)
+            course_team_mfe_enabled = toggles.use_new_course_team_page(context_course.id)
+            advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
+            import_mfe_enabled = toggles.use_new_import_page(context_course.id)
+            export_mfe_enabled = toggles.use_new_export_page(context_course.id)
 
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
+        % if not course_outline_mfe_enabled:
         <a class="course-link" href="${index_url}">
           <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
+        % endif
+        % if course_outline_mfe_enabled:
+        <a class="course-link" href="${get_course_outline_url(course_key)}">
+          <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
+          <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
+        </a>
+        % endif
       </h2>
 
       <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
@@ -72,12 +89,26 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
+                  % if not course_outline_mfe_enabled:
                   <li class="nav-item nav-course-courseware-outline">
                     <a href="${index_url}">${_("Outline")}</a>
                   </li>
+                  % endif
+                  % if course_outline_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-outline">
+                    <a href="${get_course_outline_url(course_key)}">${_("Outline")}</a>
+                  </li>
+                  % endif
+                  % if not updates_mfe_enabled:
                   <li class="nav-item nav-course-courseware-updates">
                     <a href="${course_info_url}">${_("Updates")}</a>
                   </li>
+                  % endif
+                  % if updates_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-updates">
+                    <a href="${get_updates_url(course_key)}">${_("Updates")}</a>
+                  </li>
+                  % endif
                   % if not pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-pages">
                     <a href="${tabs_url}">${_("Pages")}</a>
@@ -88,6 +119,16 @@
                     <a href="${get_pages_and_resources_url(course_key)}">${_("Pages & Resources")}</a>
                   </li>
                   % endif
+                  %if not files_uploads_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-uploads">
+                    <a href="${assets_url}">${_("Files & Uploads")}</a>
+                  </li>
+                  %endif
+                  %if files_uploads_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-uploads">
+                    <a href="${get_files_uploads_url(course_key)}">${_("Files & Uploads")}</a>
+                  </li>
+                  %endif
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${assets_url}">${_("Files & Uploads")}</a>
                   </li>
@@ -96,9 +137,14 @@
                     <a href="${textbooks_url}">${_("Textbooks")}</a>
                   </li>
                   % endif
-                  % if context_course.video_pipeline_configured:
+                  % if context_course.video_pipeline_configured and not video_upload_mfe_enabled:
                   <li class="nav-item nav-course-courseware-videos">
                     <a href="${videos_url}">${_("Video Uploads")}</a>
+                  </li>
+                  % endif
+                  % if context_course.video_pipeline_configured and video_upload_mfe_enabled:
+                  <li class="nav-item nav-course-courseware-videos">
+                    <a href="${get_video_uploads_url(course_key)}">${_("Video Uploads")}</a>
                   </li>
                   % endif
                 </ul>
@@ -112,26 +158,52 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
+                  % if not schedule_details_mfe_enabled:
                   <li class="nav-item nav-course-settings-schedule">
                     <a href="${settings_url}">${_("Schedule & Details")}</a>
                   </li>
+                  % endif
+                  % if schedule_details_mfe_enabled:
+                  <li class="nav-item nav-course-settings-schedule">
+                    <a href="${get_schedule_details_url(course_key)}">${_("Schedule & Details")}</a>
+                  </li>
+                  % endif
+                  % if not grading_mfe_enabled:
                   <li class="nav-item nav-course-settings-grading">
                     <a href="${grading_url}">${_("Grading")}</a>
                   </li>
+                  % endif
+                  % if grading_mfe_enabled:
+                  <li class="nav-item nav-course-settings-grading">
+                    <a href="${get_grading_url(course_key)}">${_("Grading")}</a>
+                  </li>
+                  % endif
+                  % if not course_team_mfe_enabled:
                   <li class="nav-item nav-course-settings-team">
                     <a href="${course_team_url}">${_("Course Team")}</a>
                   </li>
-                  <li class="nav-item nav-course-settings-group-configurations">
-                    <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': six.text_type(course_key)})}">${_("Group Configurations")}</a>
-                  </li>
-                  % if course_authoring_microfrontend_url:
-                  <li class="nav-item nav-course-settings-exams">
-                    <a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_key}">${_("Proctored Exam Settings")}</a>
+                  % endif
+                  % if course_team_mfe_enabled:
+                  <li class="nav-item nav-course-settings-team">
+                    <a href="${get_course_team_url(course_key)}">${_("Course Team")}</a>
                   </li>
                   % endif
-                  % if has_studio_advanced_settings_access(request.user):
+                  <li class="nav-item nav-course-settings-group-configurations">
+                    <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': str(course_key)})}">${_("Group Configurations")}</a>
+                  </li>
+                  % if mfe_proctored_exam_settings_url:
+                  <li class="nav-item nav-course-settings-exams">
+                    <a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a>
+                  </li>
+                  % endif
+                  % if has_studio_advanced_settings_access(request.user) and not advanced_settings_mfe_enabled:
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
+                  </li>
+                  % endif
+                  % if has_studio_advanced_settings_access(request.user) and advanced_settings_mfe_enabled:
+                  <li class="nav-item nav-course-settings-advanced">
+                    <a href="${get_advanced_settings_url(course_key)}">${_("Advanced Settings")}</a>
                   </li>
                   % endif
                   % if certificates_url:
@@ -154,15 +226,29 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
+                  % if not import_mfe_enabled:
                   <li class="nav-item nav-course-tools-import">
                     <a href="${import_url}">${_("Import")}</a>
                   </li>
+                  % endif
+                  % if import_mfe_enabled:
+                  <li class="nav-item nav-course-tools-import">
+                    <a href="${get_import_url(course_key)}">${_("Import")}</a>
+                  </li>
+                  % endif
+                  % if not export_mfe_enabled:
                   <li class="nav-item nav-course-tools-export">
                     <a href="${export_url}">${_("Export")}</a>
                   </li>
+                  % endif
+                  % if export_mfe_enabled:
+                  <li class="nav-item nav-course-tools-import">
+                    <a href="${get_export_url(course_key)}">${_("Export")}</a>
+                  </li>
+                  % endif
                   % if toggles.EXPORT_GIT.is_enabled() and context_course.giturl:
                   <li class="nav-item nav-course-tools-export-git">
-                    <a href="${reverse('export_git', kwargs=dict(course_key_string=six.text_type(course_key)))}">${_("Export to Git")}</a>
+                    <a href="${reverse('export_git', kwargs=dict(course_key_string=str(course_key)))}">${_("Export to Git")}</a>
                   </li>
                   % endif
                   <li class="nav-item nav-course-tools-checklists">
@@ -177,10 +263,10 @@
       % elif context_library:
        <%
             library_key = context_library.location.course_key
-            index_url = reverse('library_handler', kwargs={'library_key_string': six.text_type(library_key)})
-            import_url = reverse('import_handler', kwargs={'course_key_string': six.text_type(library_key)})
-            lib_users_url = reverse('manage_library_users', kwargs={'library_key_string': six.text_type(library_key)})
-            export_url = reverse('export_handler', kwargs={'course_key_string': six.text_type(library_key)})
+            index_url = reverse('library_handler', kwargs={'library_key_string': str(library_key)})
+            import_url = reverse('import_handler', kwargs={'course_key_string': str(library_key)})
+            lib_users_url = reverse('manage_library_users', kwargs={'library_key_string': str(library_key)})
+            export_url = reverse('export_handler', kwargs={'course_key_string': str(library_key)})
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Library:")}</span>
@@ -276,7 +362,7 @@
           <li class="nav-item nav-not-signedin-help">
             <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a>
           </li>
-          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
+          % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', , settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True):
               <li class="nav-item nav-not-signedin-signup">
                 <a class="action action-signup" href="${settings.FRONTEND_REGISTER_URL}?next=${quote_plus(request.build_absolute_uri(settings.LOGIN_URL))}">${_("Sign Up")}</a>
               </li>

--- a/edx-platform/bragi/lms/templates/browser-alert.html
+++ b/edx-platform/bragi/lms/templates/browser-alert.html
@@ -1,6 +1,6 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/edx-platform/bragi/lms/templates/course.html
+++ b/edx-platform/bragi/lms/templates/course.html
@@ -3,11 +3,10 @@
 <%!
 from django.utils.translation import gettext as _
 from django.urls import reverse
-from six import text_type
 %>
 <%page args="course" expression_filter="h"/>
 <article class="course" id="${course.id}" role="region" aria-label="${course.display_name_with_default}">
-  <a href="${reverse('about_course', args=[text_type(course.id)])}">
+  <a href="${reverse('about_course', args=[str(course.id)])}">
     <header class="course-image">
       <div class="cover-image">
         <img src="${course.course_image_url}" alt="${course.display_name_with_default} ${course.display_number_with_default}" />

--- a/edx-platform/bragi/lms/templates/courseware/course_about.html
+++ b/edx-platform/bragi/lms/templates/courseware/course_about.html
@@ -5,13 +5,11 @@ from django.utils.translation import pgettext
 from django.urls import reverse
 from lms.djangoapps.courseware.courses import get_course_about_section
 from django.conf import settings
-from six import text_type
 from common.djangoapps.edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import clean_dangerous_html, HTML, Text
 from openedx.core.lib.courses import course_image_url
 
-from six import string_types
 %>
 <%
   course_intro_html = theming.options('course_about', 'course_intro_html', default= False)
@@ -231,7 +229,7 @@ from six import string_types
                     account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
                     url=u"http://{domain}{path}".format(
                         domain=site_domain,
-                        path=reverse('about_course', args=[text_type(course.id)])
+                        path=reverse('about_course', args=[str(course.id)])
                     )
                 ).replace(u" ", u"+")
                 tweet_action = u"http://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=tweet_text)
@@ -246,7 +244,7 @@ from six import string_types
                         platform=platform_name,
                         url=u"http://{domain}{path}".format(
                             domain=site_domain,
-                            path=reverse('about_course', args=[text_type(course.id)]),
+                            path=reverse('about_course', args=[str(course.id)]),
                         )
                     )
                 ).replace(u" ", u"%20")

--- a/edx-platform/bragi/lms/templates/courseware/course_about_sidebar.html
+++ b/edx-platform/bragi/lms/templates/courseware/course_about_sidebar.html
@@ -5,7 +5,6 @@ from django.utils.translation import gettext as _
 from django.urls import reverse
 from django.conf import settings
 from lms.djangoapps.courseware.courses import get_course_about_section
-from six import text_type
 %>
 
 <div class="course-summary">
@@ -76,7 +75,7 @@ from six import text_type
                 account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
                 url=u"http://{domain}{path}".format(
                     domain=site_domain,
-                    path=reverse('about_course', args=[text_type(course.id)])
+                    path=reverse('about_course', args=[str(course.id)])
                 )
             ).replace(u" ", u"+")
             tweet_action = u"http://twitter.com/intent/tweet?text={tweet_text}".format(tweet_text=tweet_text)
@@ -91,7 +90,7 @@ from six import text_type
                     platform=platform_name,
                     url=u"http://{domain}{path}".format(
                         domain=site_domain,
-                        path=reverse('about_course', args=[text_type(course.id)]),
+                        path=reverse('about_course', args=[str(course.id)]),
                     )
                 )
             ).replace(u" ", u"%20")

--- a/edx-platform/bragi/lms/templates/courseware/courses.html
+++ b/edx-platform/bragi/lms/templates/courseware/courses.html
@@ -1,6 +1,6 @@
 <%!
   import json
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>
 <%inherit file="../main.html" />

--- a/edx-platform/bragi/lms/templates/dashboard.html
+++ b/edx-platform/bragi/lms/templates/dashboard.html
@@ -4,7 +4,6 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 import pytz
-import six
 from datetime import datetime, timedelta
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -302,7 +301,7 @@ from common.djangoapps.student.models import CourseEnrollment
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)
                 is_course_voucher_refundable = (session_id in enrolled_courses_voucher_refundable)
                 course_requirements = courses_requirements_not_met.get(session_id)
-                related_programs = inverted_programs.get(six.text_type(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
+                related_programs = inverted_programs.get(str(entitlement.course_uuid if is_unfulfilled_entitlement else session_id))
                 show_consent_link = (session_id in consent_required_courses)
                 resume_button_url = resume_button_urls[dashboard_index]
               %>

--- a/edx-platform/bragi/lms/templates/eox-tenant/not_found.html
+++ b/edx-platform/bragi/lms/templates/eox-tenant/not_found.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <%!
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
   from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/edx-platform/bragi/lms/templates/head-extra.html
+++ b/edx-platform/bragi/lms/templates/head-extra.html
@@ -1,7 +1,7 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.translation import get_language_bidi
 %>
 <%namespace name='static' file='static_content.html'/>

--- a/edx-platform/bragi/lms/templates/header/navbar-not-authenticated.html
+++ b/edx-platform/bragi/lms/templates/header/navbar-not-authenticated.html
@@ -9,7 +9,6 @@
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as _
-from six import text_type
 
 from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_microfrontend
 %>
@@ -20,7 +19,7 @@ from openedx.core.djangoapps.user_authn.toggles import should_redirect_to_authn_
   allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
   can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
   restrict_enroll_for_course = course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain
-  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')) and settings.FEATURES.get('SHOW_REGISTRATION_LINKS', True)
   should_redirect_to_authn_mfe = should_redirect_to_authn_microfrontend()
 %>
 <nav aria-label=${_("Supplemental Links")}> 

--- a/edx-platform/bragi/lms/templates/lang_selector.html
+++ b/edx-platform/bragi/lms/templates/lang_selector.html
@@ -1,7 +1,7 @@
 ## mako
 <%!
   from django.urls import reverse
-  from django.utils.translation import ugettext as _
+  from django.utils.translation import gettext as _
 
   from babel import Locale
   from openedx.core.djangoapps.lang_pref.api import released_languages

--- a/edx-platform/bragi/lms/templates/learner_profile/learner_profile.html
+++ b/edx-platform/bragi/lms/templates/learner_profile/learner_profile.html
@@ -8,7 +8,7 @@
 <%!
 import json
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.djangolib.markup import HTML
 %>

--- a/edx-platform/bragi/lms/templates/main.html
+++ b/edx-platform/bragi/lms/templates/main.html
@@ -14,10 +14,9 @@
 <%namespace name='static' file='static_content.html'/>
 <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
 <%!
-import six
 from lms.djangoapps.branding import api as branding_api
 from django.urls import reverse
-from django.utils.http import urlquote_plus
+from urllib.parse import quote_plus
 from django.utils.translation import gettext as _
 from django.utils.translation import get_language_bidi
 from lms.djangoapps.courseware.access import has_access
@@ -91,7 +90,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
       <%
       rtl_css_file = self.attr.main_css.replace('.css', '-rtl.css')
       %>
-      <link rel="stylesheet" href="${six.text_type(static.url(rtl_css_file))}" type="text/css" media="all" />
+      <link rel="stylesheet" href="${str(static.url(rtl_css_file))}" type="text/css" media="all" />
     % else:
       <link rel="stylesheet" href="${static.url(self.attr.main_css)}" type="text/css" media="all" />
     % endif
@@ -233,6 +232,6 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 
 <%def name="login_query()">${
   u"?next={next}".format(
-    next=urlquote_plus(login_redirect_url if login_redirect_url else request.path)
+    next=quote_plus(login_redirect_url if login_redirect_url else request.path)
   ) if (login_redirect_url or (request and not request.path.startswith("/logout"))) else ""
 }</%def>

--- a/edx-platform/bragi/lms/templates/static_templates/about.html
+++ b/edx-platform/bragi/lms/templates/static_templates/about.html
@@ -1,6 +1,6 @@
 <%! 
 	from django.urls import reverse
-	from django.utils.translation import ugettext as _
+	from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/edx-platform/bragi/lms/templates/static_templates/contact.html
+++ b/edx-platform/bragi/lms/templates/static_templates/contact.html
@@ -1,6 +1,6 @@
 <%! 
 	from django.urls import reverse
-	from django.utils.translation import ugettext as _
+	from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/edx-platform/bragi/lms/templates/static_templates/faq.html
+++ b/edx-platform/bragi/lms/templates/static_templates/faq.html
@@ -1,6 +1,6 @@
 <%! 
 	from django.urls import reverse
-	from django.utils.translation import ugettext as _
+	from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/edx-platform/bragi/lms/templates/static_templates/honor.html
+++ b/edx-platform/bragi/lms/templates/static_templates/honor.html
@@ -1,6 +1,6 @@
 <%! 
 	from django.urls import reverse
-	from django.utils.translation import ugettext as _
+	from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/edx-platform/bragi/lms/templates/static_templates/privacy.html
+++ b/edx-platform/bragi/lms/templates/static_templates/privacy.html
@@ -1,6 +1,6 @@
 <%! 
 	from django.urls import reverse
-	from django.utils.translation import ugettext as _
+	from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/edx-platform/bragi/lms/templates/static_templates/tos.html
+++ b/edx-platform/bragi/lms/templates/static_templates/tos.html
@@ -1,6 +1,6 @@
 <%! 
 	from django.urls import reverse
-	from django.utils.translation import ugettext as _
+	from django.utils.translation import gettext as _
 %>
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>

--- a/edx-platform/bragi/lms/templates/student_account/login_and_register.html
+++ b/edx-platform/bragi/lms/templates/student_account/login_and_register.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
     import json
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
     from openedx.core.djangolib.js_utils import dump_js_escaped_json
 %>


### PR DESCRIPTION
## Description
This PR updates the Bragi templates according to the new OpenEdx Quince release. Despite there are some issues with `bragi-children` templates, these are out of the scope of the [JIRA ISSUE](https://edunext.atlassian.net/browse/DS-779) and the solution will be addressed in future efforts.

#### How to test

- Be sure you have eox-tenant and eox-theming in your environment. 
- Clone the repo in `env/build/openedx/themes` and be sure to use the current branch `bc/add-quince-support`

- Add this line in `env/build/openedx/settings/lms/assets.py` and `env/build/openedx/settings/cms/assets.py `

```python
COMPREHENSIVE_THEME_DIRS.extend(['/openedx/themes/ednx-saas-themes/edx-platform'])
```

- In the `lms.env.yml `and `cms.env.yml` be sure to add:

```yml
USE_EOX_TENANT: True
DEFAULT_SITE_THEME: "bragi"
COMPREHENSIVE_THEME_DIRS: ["/openedx/themes/ednx-saas-themes/edx-platform"]

```
- Open bash and compile bragi theme, [context](https://github.com/eduNEXT/tutor-contrib-edunext-distro#how-to-add-a-theme)

```
source .tvm/bin/activate
tutor dev run lms bash
# Inside the lms bash 
openedx-assets themes --theme-dirs /openedx/themes/ednx-saas-themes/edx-platform --themes bragi
```

Now you'll see the default bragi theme applied in all LMS and any error about mako templates. Be sure you don't have selected any `bragi-children` in the `THEME_OPTIONS` in the tenant configs 

### Evidence
#### Without bragi
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/ea112daf-456c-42ab-aa17-97cf9ceac8bd)


#### With bragi
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/7cbb9a03-9289-4478-b014-793c5d44398a)

More Context 
[Jira Card DS-779](https://edunext.atlassian.net/browse/DS-779)
