### PR TITLE
fix: hide the new ora grading demo button from the coursewere

### DIFF
--- a/edx-platform/bragi-children/css-runtime/lms/static/sass/partials/lms/theme/_xblock.scss
+++ b/edx-platform/bragi-children/css-runtime/lms/static/sass/partials/lms/theme/_xblock.scss
@@ -37,3 +37,13 @@
 .mce-container-body .mce-ico {
 	font-family: 'tinymce', Arial !important;
 }
+
+
+
+/* ========================================================
+  ORA Grading MFE demo button
+======================================================== */
+
+.wrapper--openassessment .wrapper--staff-area .wrapper--staff-toolbar .button-enhanced-staff-grader-demo {
+  display: none !important;
+}

--- a/edx-platform/bragi/lms/static/sass/partials/lms/theme/_xblock.scss
+++ b/edx-platform/bragi/lms/static/sass/partials/lms/theme/_xblock.scss
@@ -30,3 +30,12 @@
 .mce-container-body .mce-ico {
 	font-family: 'tinymce', Arial !important;
 }
+
+
+/* ========================================================
+  ORA Grading MFE demo button
+======================================================== */
+
+.wrapper--openassessment .wrapper--staff-area .wrapper--staff-toolbar .button-enhanced-staff-grader-demo {
+  display: none !important;
+}


### PR DESCRIPTION
Since Version 4.2.0 of the ORA Grading plugin, a new button is [set by default](https://github.com/openedx/edx-ora2/blob/4.2.0/openassessment/templates/openassessmentblock/staff_area/oa_staff_area.html#L21) in the template to invite the staff members of the course to try the new MFE if this one is not activated, due to each instance could rather enable or not this MFE hide the button is necessary to avoid redirections to an inexistent page. 

**Before**
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/66016493/7d2165bd-7072-478a-9430-d4326c274d85)

**After**
![image](https://github.com/eduNEXT/ednx-saas-themes/assets/66016493/59b47675-f2cb-4d27-91cf-b020007e3a45)


**How to test**

- Unactive Ora-Grading MFE, you can follow the instructions in tutor-mfe version 16
- Configure an environment with bragi (you can use distro plugin in plama version)
- Create a course with ORA problem configured with staff assignment.
- Go to the courseware and the button should not be displayed. 