### PR TITLE
fix: improve styles for rtl languages in course about

### DIFF
--- a/edx-platform/bragi-children/css-runtime/lms/static/sass/partials/lms/theme/_about.scss
+++ b/edx-platform/bragi-children/css-runtime/lms/static/sass/partials/lms/theme/_about.scss
@@ -174,7 +174,6 @@
 
 	.teacher-image {
 		@include float(left);
-		@include margin(0, 15px, 0, 0);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -182,6 +181,13 @@
 		overflow: hidden;
 		border: 1px solid #c8c8c8;
 	}
+}
+
+.content-wrapper[dir="ltr"] .course-info .details .inner-wrapper .course-staff .teacher .teacher-image {
+	margin:0 15px 0 0;
+}
+.content-wrapper[dir="rtl"] .course-info .details .inner-wrapper .course-staff .teacher .teacher-image {
+	margin:0 0 0 15px;
 }
 
 /* ========================================================

--- a/edx-platform/bragi/lms/static/sass/partials/lms/theme/_about.scss
+++ b/edx-platform/bragi/lms/static/sass/partials/lms/theme/_about.scss
@@ -174,7 +174,6 @@
 
 	.teacher-image {
 		@include float(left);
-		@include margin(0, 15px, 0, 0);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -182,6 +181,13 @@
 		overflow: hidden;
 		border: 1px solid #c8c8c8;
 	}
+}
+ 
+.content-wrapper[dir="ltr"] .course-info .details .inner-wrapper .course-staff .teacher .teacher-image {
+	margin:0 15px 0 0;
+}
+.content-wrapper[dir="rtl"] .course-info .details .inner-wrapper .course-staff .teacher .teacher-image {
+	margin:0 0 0 15px;
 }
 
 /* ========================================================

--- a/edx-platform/bragi/lms/templates/courseware/course_about.html
+++ b/edx-platform/bragi/lms/templates/courseware/course_about.html
@@ -9,6 +9,8 @@ from common.djangoapps.edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import clean_dangerous_html, HTML, Text
 from openedx.core.lib.courses import course_image_url
+from django.utils.translation import get_language_bidi
+
 
 %>
 <%
@@ -140,7 +142,7 @@ from openedx.core.lib.courses import course_image_url
           <div>${get_course_about_section(request, course, 'short_description')}</div>
         </div>
 
-        <div class="main-cta ml-2 col-md-3 text-center">
+        <div class="main-cta ${'mr-2' if get_language_bidi() else 'ml-2'} col-md-3 text-center">
           %if user.is_authenticated and registered:
             %if show_courseware_link:
               <a class="btn" href="${course_target}">
@@ -196,7 +198,7 @@ from openedx.core.lib.courses import course_image_url
 
     <div class="course-info__content row container mt-5 p-4">
 
-      <div class="details col col-12 mr-0">
+      <div class="details col col-12 ${'ml-0' if get_language_bidi() else 'mr-0'}">
         % if course_text_into_html:
           ${course_text_into_html | n, decode.utf8}
         % endif
@@ -347,7 +349,7 @@ from openedx.core.lib.courses import course_image_url
           <h1 class="course-title d-flex mb-2">
             ${course.display_name_with_default_escaped}
 
-            <div class="main-cta ml-2 text-center">
+            <div class="main-cta ${'mr-2' if get_language_bidi() else 'ml-2'} text-center">
               %if user.is_authenticated and registered:
                 %if show_courseware_link:
                   <a class="btn" href="${course_target}">
@@ -409,7 +411,7 @@ from openedx.core.lib.courses import course_image_url
         <%include file="./course_about_sidebar.html" />
       </div>
 
-      <div class="details col col-12 col-lg-9 mr-0">
+      <div class="details col col-12 col-lg-9 ${'ml-0' if get_language_bidi() else 'mr-0'}">
         % if course_text_into_html:
           ${course_text_into_html | n, decode.utf8}
         % endif


### PR DESCRIPTION
This PR updates some styles for the course about page to fix some problems identified with rtl languages:

That includes:
- Space between the enroll button and course title, and space between teacher images and text.
- Fix the course about sidebar position. 


[scrnli_2_8_2024_5-33-12 PM.webm](https://github.com/eduNEXT/ednx-saas-themes/assets/66016493/a2add361-7448-44b1-bcd0-695bc24509cf)


**How to test**

- Create an instance with bragi and a course 
- Create a new tenant and add 'ar' as  language by default or inside released languages, for example:
```
    "header_langselector": true,
    "released_languages": "en,ru,fr,es-419,de-DE,pt-BR,ar"
```
- Go to the course about page and check the styles. 

This solves https://github.com/eduNEXT/ednx-saas-themes/issues/158

[JIRA](https://edunext.atlassian.net/browse/DS-797)