### PR TITLE
refactor: add enabling course authoring flag to proper render when using bragi

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -15,6 +15,7 @@
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 
   logo_image_studio = configuration_helpers.get_value('STUDIO_LOGO_URL', '')
+  from cms.lib.utils import use_course_authoring_mfe
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -52,7 +53,7 @@
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
+            pages_and_resources_mfe_enabled = use_course_authoring_mfe(course_key.org) and ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
 
       %>
       <h2 class="info-course">


### PR DESCRIPTION
## Description
This PR adds the recently created [use_course_authoring_mfe](https://github.com/eduNEXT/edunext-platform/pull/808) so is available the proper behavior when bragi is activated.

The template modified in this PR overrode the template from edunext-platform which causes, when the MFE was disabled, the template wasn't shown as needed because this template didn't have the needed conditional applied

## How to test
First, meanwhile the PRs are approved, make sure that the 'TARGET REVISION' in ArgoCD is pointing to the branch 
`bc/test_course_authoring_setting` of the manifest

![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/c2238d73-073c-40ed-a024-cf38aea087ec)


Go to https://studio.amberes.dedalo.edunext.link/course/course-v1:tenantB+CS432+2024_T5 and you should be able to see the 'Pages' option when in the tenant configs the flag ENABLE_COURSE_AUTHORING_MFE is not used or its value is `false`

![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/789c6b5d-9fa7-48c8-8f42-acae69ed3e2a)
