### PR TITLE
fix: make the tab color in courseware same as mfe

### DIFF
--- a/edx-platform/bragi-children/css-runtime/lms/static/sass/partials/lms/theme/_course.scss
+++ b/edx-platform/bragi-children/css-runtime/lms/static/sass/partials/lms/theme/_course.scss
@@ -364,27 +364,27 @@ main .home {
 .view-in-course {
   .wrapper-course-material .course-tabs li a {
     &.active, &:hover, &:focus {
-      color: var(--pgn-color-link-base) !important;
-      border-bottom-color: var(--pgn-color-link-base) !important;
+      color: var(--pgn-color-primary-500) !important;
+      border-bottom-color: var(--pgn-color-primary-500) !important;
     }
   }
 }
 .content-wrapper .course-tabs .nav-item{
   &.active .nav-link, &:hover .nav-link {
-    color: var(--pgn-color-link-base) !important;
-    border-bottom-color: var(--pgn-color-link-base) !important;
+    color: var(--pgn-color-primary-500) !important;
+    border-bottom-color: var(--pgn-color-primary-500) !important;
   }
 }
 
 .instructor-dashboard-content-2 .instructor-nav .nav-item .btn-link, 
 .instructor-dashboard-content-2 .data-download-nav .nav-item .btn-link {
-  color: var(--pgn-color-link-base);
+  color: var(--pgn-color-primary-500);
   &.active, &:hover, &:focus   {
-    border-bottom-color: var(--pgn-color-link-base) !important;
+    border-bottom-color:var(--pgn-color-primary-500) !important;
   }
   &.active-section, &.active-section {
     color: var(--pgn-color-black) ;
-    border-bottom-color: var(--pgn-color-link-base) !important;
+    border-bottom-color: var(--pgn-color-primary-500) !important;
   }
 }
 


### PR DESCRIPTION
**Description**

This PR changed the color from link-base to primary-500 in the tabs for the courseware to make it equal to the theming inside the learning MFE. 

_**Before**_

![image](https://github.com/eduNEXT/ednx-saas-themes/assets/66016493/9d40df76-2af2-4918-9fb7-893f7b1c58cc)

_**After**_

![image](https://github.com/eduNEXT/ednx-saas-themes/assets/66016493/79cc84d6-c735-4924-9a97-fe8ff094ba82)

[JIRA](https://edunext.atlassian.net/browse/DS-850)
