### PR TITLE
revert: use course authoring new enabling flag (#210)

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -14,7 +14,6 @@
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 
   logo_image_studio = configuration_helpers.get_value('STUDIO_LOGO_URL', '')
-  from cms.lib.utils import use_course_authoring_mfe
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -52,7 +51,7 @@
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
-            pages_and_resources_mfe_enabled = use_course_authoring_mfe(course_key.org) and ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
+            pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
             course_outline_mfe_enabled = toggles.use_new_course_outline_page(context_course.id)
             updates_mfe_enabled = toggles.use_new_updates_page(context_course.id)
             files_uploads_mfe_enabled = toggles.use_new_files_uploads_page(context_course.id)
@@ -63,6 +62,7 @@
             advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
             import_mfe_enabled = toggles.use_new_import_page(context_course.id)
             export_mfe_enabled = toggles.use_new_export_page(context_course.id)
+
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>


### PR DESCRIPTION
This PR removes the course authoring flag for Redwood and subsequent releases understanding we want to use the MFE by for instance and not for tenant. 