### PR TITLE
docs: write a basic documentation about migration and instalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ If you want to use ``css-runtime`` you need to add the following configuration t
 }
 ```
 
-Otherwise add the theme with these steps:
+Otherwise, to add the Bragi theme in a instance follow these steps:
 
 1. Be sure you have eox-tenant and eox-theming in your environment.
 2. Clone the repo in ``env/build/openedx/themes`` and use the branch to work with.
-3. Add this line in ``env/build/openedx/settings/lms/assets.py and env/build/openedx/settings/cms/assets.py``
+3. Add this line in ``env/build/openedx/settings/lms/assets.py`` and ``env/build/openedx/settings/cms/assets.py``
 
 ```py
 COMPREHENSIVE_THEME_DIRS.extend(['/openedx/themes/ednx-saas-themes/edx-platform', '/openedx/themes/ednx-saas-themes/edx-platform/bragi-children'])
 ```
 
 
-In the ``lms.env.ym``l`` and ``cms.env.yml`` be sure to add:
+In the ``lms.env.yml`` and ``cms.env.yml`` be sure to add:
 
 ```py
 USE_EOX_TENANT: True
@@ -84,7 +84,7 @@ Let's review different scenarios and the action to take in each one:
 
 Imagine the current version of Bragi is Alpha and we need to migrate to Beta. The step by step is:
 
-1. Create a new branch based on master. The name of your branch should follow the structure <name_initials>/<description>, e,g. jd/beta-migration.
+1. Create a new branch based on master. The name of your branch should follow the structure ``<name_initials>/<description>``, e,g. ``jd/beta-migration``.
 
 2. We have a document for the [migration tracking](https://docs.google.com/spreadsheets/d/1ly7rxyyHK-DvUS2hBpqylONlZC_MWqYkxPOV6dmPG1k/edit#gid=0). You should create a new page, duplicate the table, and fill the status and description columns with your findings and changes. The name of the page is the releases involved in the migration, e.g. Alpha to Beta.
 
@@ -94,22 +94,22 @@ Imagine the current version of Bragi is Alpha and we need to migrate to Beta. Th
 
 5. Diff the changes between templates in Alpha (upstream) and Beta. You can use [Diffchecker](https://www.diffchecker.com/text-compare/#editor) to compare them. This helps you as a filter to identify which templates you need to modify.
 
-6. Diff the templates in Bragi Alpha with upstream Alpha from those with changes (step 3), this helps you to identify the Bragi customizations overwritten.
+6. Diff the templates in Bragi Alpha with upstream Alpha from those with changes (step 5), this helps you to identify the Bragi customizations overwritten.
 
-7. For the template Beta identified in step 3 add the Bragi customizations (step 4).
+7. For the template Beta identified in step 5 add the Bragi customizations (step 6).
 
-8. Verify the styles are correct if not make the corresponding changes.
+8. Verify the styles are correct, if not, make the corresponding changes.
 
 9. Create a tenant to verify the custom variables are being applied.
 
 10. Create a Pull Request to master with the migrated templates and styles updated.
 
-11. Once the changes are approved and merged, create a branch for the new release, following the repository standard edunext/<release-name>.master, e.g. edunext/beta.master.
+11. Once the changes are approved and merged, create a branch for the new release, following the repository standard ``edunext/<release-name>.master``, e.g. ``edunext/beta.master``.
 
 >[!TIP]
->You can follow steps 3 to 5 for each template so you can update the tracking documentation at the same time.
+>You can follow steps 3 to 6 for each template so you can update the tracking documentation at the same time.
 
-For a detailed explanation of Bragi, the migration process, and how it works with eox-theming, please review the following video: https://www.youtube.com/watch?v=A9bEQm4zUWI
+For a detailed explanation of Bragi, the migration process, and how it works with eox-theming, please review the following video: [Onboarding Bragi](https://www.youtube.com/watch?v=A9bEQm4zUWI)
 
 
 ## Technical Details
@@ -120,9 +120,9 @@ For a detailed explanation of Bragi, the migration process, and how it works wit
 - [django](https://docs.djangoproject.com/en/5.1/ref/templates/language/)
 - [Mako](https://www.makotemplates.org/)
 
-## Learn More
+## Technical Notes
 
-* We no longer use `bragi-generator` and `bragi-childrens` (maintaining `css-runtime`) themes since Nutmeg.
+* We no longer use `bragi-generator` and `bragi-childrens` themes since Nutmeg. With the introduction of CSS Variables in the Open edX ecosystem we are currently maintaining `css-runtime` and `bragi` themes.
 
 ## License
 


### PR DESCRIPTION
This PR add the steps necessary for installing the theme in a instance, also add the steps to migrate the templates from a openedx version to another. 