### PR TITLE
perf: added teak support

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -8,8 +8,7 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url
-  from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_course_libraries_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url, get_optimizer_url  from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
   from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 
@@ -62,6 +61,8 @@
             advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
             import_mfe_enabled = toggles.use_new_import_page(context_course.id)
             export_mfe_enabled = toggles.use_new_export_page(context_course.id)
+            optimizer_enabled = toggles.enable_course_optimizer(context_course.id)
+            libraries_v2_enabled = toggles.libraries_v2_enabled()
 
       %>
       <h2 class="info-course">
@@ -92,6 +93,11 @@
                   % if not course_outline_mfe_enabled:
                   <li class="nav-item nav-course-courseware-outline">
                     <a href="${index_url}">${_("Outline")}</a>
+                  </li>
+                  % endif
+                  % if libraries_v2_enabled:
+                  <li class="nav-item nav-course-courseware-outline">
+                    <a href="${get_course_libraries_url(course_key)}">${_("Libraries")}</a>
                   </li>
                   % endif
                   % if course_outline_mfe_enabled:
@@ -239,7 +245,7 @@
                   </li>
                   % endif
                   % if export_mfe_enabled:
-                  <li class="nav-item nav-course-tools-import">
+                  <li class="nav-item nav-course-tools-export">
                     <a href="${get_export_url(course_key)}">${_("Export")}</a>
                   </li>
                   % endif
@@ -251,6 +257,11 @@
                   <li class="nav-item nav-course-tools-checklists">
                     <a href="${checklists_url}">${_("Checklists")}</a>
                   </li>
+                  % if optimizer_enabled:
+                  <li class="nav-item">
+                    <a href="${get_optimizer_url(course_key)}">${_("Course Optimizer")}</a>
+                  </li>
+                  % endif
                 </ul>
               </div>
             </div>

--- a/edx-platform/bragi/lms/templates/header/user_dropdown.html
+++ b/edx-platform/bragi/lms/templates/header/user_dropdown.html
@@ -4,6 +4,7 @@
 
 <%!
 import json
+from urllib.parse import urljoin
 
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -40,8 +41,8 @@ enterprise_customer_portal = get_enterprise_learner_portal(request)
         % else:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL}/${enterprise_customer_portal.get('slug')}" role="menuitem">${_("Dashboard")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('learner_profile', kwargs={'username': username})}" role="menuitem">${_("Profile")}</a></div>
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('account_settings')}" role="menuitem">${_("Account")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${urljoin(settings.PROFILE_MICROFRONTEND_URL, f'/u/{user.username}')}" role="menuitem">${_("Profile")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ACCOUNT_MICROFRONTEND_URL}" role="menuitem">${_("Account")}</a></div>
         <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
     </div>
 </div>

--- a/edx-platform/bragi/lms/templates/widgets/help-sidebar.html
+++ b/edx-platform/bragi/lms/templates/widgets/help-sidebar.html
@@ -49,7 +49,7 @@
                 </p>
                 <p>
                 Your use of this edunext cloud subscription is bound by our <a href="https://www.edunext.co/terms-of-use/" style="color:#00d47d;">terms of service</a>, and <a href="https://www.edunext.co/privacy/" style="color:#00d47d;">privacy policy</a>
-                Copyright © 2024 edunext, All rights reserved.<br>
+                Copyright © 2025 edunext, All rights reserved.<br>
                 </p>
             </div>
             <div class="ednx-button-container" style="display:flex; justify-content: center; margin: 14px">


### PR DESCRIPTION
## Description
This PR updates the Bragi templates according to the new OpenEdx Teak release.

#### How to test

- Be sure you have eox-tenant and eox-theming in your environment. 
- Clone the repo in `env/build/openedx/themes` and be sure to use the current branch `edunext/teak.master`

- Add this line in `env/build/openedx/settings/lms/assets.py` and `env/build/openedx/settings/cms/assets.py `

```python
COMPREHENSIVE_THEME_DIRS.extend(['/openedx/themes/ednx-saas-themes/edx-platform'])
```

- In the `lms.env.yml `and `cms.env.yml` be sure to add:

```yml
USE_EOX_TENANT: True
DEFAULT_SITE_THEME: "bragi"
COMPREHENSIVE_THEME_DIRS: ["/openedx/themes/ednx-saas-themes/edx-platform"]

```
- Open bash and compile bragi theme, [context](https://github.com/eduNEXT/tutor-contrib-edunext-distro#how-to-add-a-theme)

```
source .tvm/bin/activate
tutor dev run lms bash
# Inside the lms bash 
npm run compile-sass -- --theme-dir /openedx/themes/ednx-saas-themes/edx-platform --theme bragi
./manage.py lms collectstatic --noinput
./manage.py cms collectstatic --noinput
```

Now you'll see the default bragi theme applied in all LMS and any error about mako templates. Be sure you don't have selected any `bragi-children` in the `THEME_OPTIONS` in the tenant configs 

before:
![image](https://github.com/user-attachments/assets/40e1a264-d838-4ba7-b721-bdadc5cdaf7b)

After:
![image](https://github.com/user-attachments/assets/0c22d755-376e-4da2-b869-4d25acca393a)
