### PR TITLE
fix: fixing import syntax in cms header widget (#236)

### DIFF
--- a/edx-platform/bragi/cms/templates/widgets/header.html
+++ b/edx-platform/bragi/cms/templates/widgets/header.html
@@ -8,7 +8,8 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_course_libraries_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url, get_optimizer_url  from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_course_libraries_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url, get_optimizer_url  
+  from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
   from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
 


### PR DESCRIPTION
# Description

This PR applies a syntax error fix in the CMS header.