### PR TITLE
fix: fail load on css_overrides_file_extra

### DIFF
--- a/edx-platform/bragi-children/css-runtime/lms/templates/head-extra.html
+++ b/edx-platform/bragi-children/css-runtime/lms/templates/head-extra.html
@@ -3,6 +3,7 @@
 <%!
 from django.utils.translation import gettext as _
 from django.utils.translation import get_language_bidi
+from django.templatetags.static import static as static_url_func
 %>
 <%namespace name='static' file='static_content.html'/>
 
@@ -14,7 +15,6 @@ from django.utils.translation import get_language_bidi
         'css_overrides_file_rtl',
         default = theming.options('css_overrides_file')
       )
-      style_overrides_file = theming.options('css_overrides_file')
     else:
       style_overrides_file = theming.options('css_overrides_file')
   except Exception:
@@ -27,13 +27,13 @@ from django.utils.translation import get_language_bidi
 
 ## Optional overrides
 <%
-  style_overrides_file_extra = theming.options('css_overrides_file_extra', default= "css-runtime/css/bragi/variables.css")
-  style_overrides_inline_extra = theming.options('css_overrides_inline_extra', default= False)
+  style_overrides_file_extra = theming.options('css_overrides_file_extra', default=static_url_func("css-runtime/css/bragi/variables.css"))
+  style_overrides_inline_extra = theming.options('css_overrides_inline_extra', default=False)
 %>
 <link rel="stylesheet" type="text/css" href="${static.url('css-runtime/css/core/variables.css')}" />
 <link rel="stylesheet" type="text/css" href="${static.url('css-runtime/css/bragi/utility-classes.css')}" />
 % if style_overrides_file_extra:
-  <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file_extra)}" />
+  <link rel="stylesheet" type="text/css" href="${style_overrides_file_extra}" />
 % endif
 % if style_overrides_inline_extra:
   <style type="text/css">${style_overrides_inline_extra | n}</style>


### PR DESCRIPTION
This PR fixes an issue where providing an absolute URL (e.g., from a CDN) in the `css_overrides_file_extra` theme option would result in a broken path or a 500 error when deployed in the `edunext/ulmo.master` release branch.

## Context & Problem

Previously, the head-extra.html template wrapped the `style_overrides_file_extra` variable inside `${static.url(...)}` directly in the <link> tag:

`<link ... href="${static.url(style_overrides_file_extra)}" />`

This logic assumed that the value was always a relative local static file. If a user configured an external URL (e.g., https://cdn.example.com/custom.css), static.url() would incorrectly attempt to resolve it relative to the static root (resulting in paths like /static/https://...) or fail the manifest lookup in the ulmo.master build.

## Solution

The logic for static.url() has been moved to the variable assignment stage.

Default Value: The static.url() function is now applied only to the default local path string within the `theming.options` call.

HTML Rendering: The <link> tag now renders ${style_overrides_file_extra} directly.

This ensures that:

If the value falls back to the default, it is correctly resolved as a static asset.

If the value is provided via configuration (e.g., an external URL), it is rendered as-is without modification.

## Changes

- edx-platform/bragi-children/css-runtime/lms/templates/head-extra.html:

Moved static.url() wrapper to the default parameter of theming.options.

Removed static.url() wrapper from the href attribute in the HTML link tag.

## Testing

Scenario A (Default/Local): Verify that when no override is configured, the default local CSS (css-runtime/css/bragi/variables.css) still loads correctly with the static prefix (e.g., /static/css-runtime/...).

Scenario B (External URL): Configure css_overrides_file_extra with an absolute URL (e.g., https://example.com/style.css). Verify that the rendered HTML <link> tag contains the exact URL without prepended static paths.

<img width="1920" height="1053" alt="image" src="https://github.com/user-attachments/assets/3031da16-cd67-4924-a271-827c424c4bf7" />
